### PR TITLE
Adding Cutout + BackWall Offset for MultiConnectRoundSingleHolder.scad

### DIFF
--- a/MultiConnectRoundSingleHolder.scad
+++ b/MultiConnectRoundSingleHolder.scad
@@ -66,7 +66,7 @@ union() {
                     circle(r = itemDiameter/2+rimThickness, $fn=50);
         }
         //itemDiameter (i.e., delete tool)
-        translate(v = [totalWidth/2,(itemDiameter/2)+offSet,baseThickness - (useCutout?+(baseThickness*2):0)]) linear_extrude(height = shelfSupportHeight+rimHeight+1+(useCutout?+(baseThickness*2):0)) circle(r = itemDiameter/2, $fn=50);
+        translate(v = [totalWidth/2,(itemDiameter/2)+offSet,baseThickness+.5 - (useCutout?+(baseThickness*2)+1:0)]) linear_extrude(height = shelfSupportHeight+rimHeight+1+(useCutout?+(baseThickness*2):0)) circle(r = itemDiameter/2, $fn=50);
     }
     //brackets
     bracketSize = min(totalHeight-baseThickness-shelfSupportHeight, itemDiameter/2);

--- a/MultiConnectRoundSingleHolder.scad
+++ b/MultiConnectRoundSingleHolder.scad
@@ -18,7 +18,7 @@ rimHeight = 10;
 additionalBackerHeight = 0;
 //Offset the holding position from the back wall
 offSet = 0;
-//use cutout
+//Use cutout for holding items that are wider at the top
 useCutout = false;
 
 /*[Slot Customization]*/

--- a/MultiConnectRoundSingleHolder.scad
+++ b/MultiConnectRoundSingleHolder.scad
@@ -61,15 +61,12 @@ union() {
                             square(size = [totalWidth,1]);
                 }
             //thin holding wall
-            if (!useCutout) 
-            {
             translate(v = [totalWidth/2,itemDiameter/2+offSet,shelfSupportHeight+baseThickness]) 
                 linear_extrude(height = rimHeight) 
                     circle(r = itemDiameter/2+rimThickness, $fn=50);
-            }
         }
         //itemDiameter (i.e., delete tool)
-        translate(v = [totalWidth/2,(itemDiameter/2)+offSet,baseThickness - (useCutout ? - (-baseThickness*2):0)]) linear_extrude(height = shelfSupportHeight+rimHeight+1) circle(r = itemDiameter/2, $fn=50);
+        translate(v = [totalWidth/2,(itemDiameter/2)+offSet,baseThickness - (useCutout?+(baseThickness*2):0)]) linear_extrude(height = shelfSupportHeight+rimHeight+1+(useCutout?+(baseThickness*2):0)) circle(r = itemDiameter/2, $fn=50);
     }
     //brackets
     bracketSize = min(totalHeight-baseThickness-shelfSupportHeight, itemDiameter/2);

--- a/MultiConnectRoundSingleHolder.scad
+++ b/MultiConnectRoundSingleHolder.scad
@@ -16,6 +16,10 @@ shelfSupportHeight = 3;
 rimHeight = 10;
 //Additional Backer Height (in mm) in case you prefer additional support for something heavy
 additionalBackerHeight = 0;
+//Offset the holding position from the back wall
+offSet = 0;
+//use cutout
+useCutout = false;
 
 /*[Slot Customization]*/
 //Distance between Multiconnect slots on the back (25mm is standard for MultiBoard)
@@ -48,7 +52,7 @@ union() {
         //itemwalls
         union() {
             hull(){
-                translate(v = [totalWidth/2,itemDiameter/2,0]) 
+                translate(v = [totalWidth/2,itemDiameter/2+offSet,0]) 
                     //outer circle
                     linear_extrude(height = shelfSupportHeight+baseThickness) 
                             circle(r = itemDiameter/2+rimThickness, $fn=50);
@@ -57,12 +61,15 @@ union() {
                             square(size = [totalWidth,1]);
                 }
             //thin holding wall
-            translate(v = [totalWidth/2,itemDiameter/2,shelfSupportHeight+baseThickness]) 
+            if (!useCutout) 
+            {
+            translate(v = [totalWidth/2,itemDiameter/2+offSet,shelfSupportHeight+baseThickness]) 
                 linear_extrude(height = rimHeight) 
                     circle(r = itemDiameter/2+rimThickness, $fn=50);
+            }
         }
         //itemDiameter (i.e., delete tool)
-        translate(v = [totalWidth/2,itemDiameter/2,baseThickness]) linear_extrude(height = shelfSupportHeight+rimHeight+1) circle(r = itemDiameter/2, $fn=50);
+        translate(v = [totalWidth/2,(itemDiameter/2)+offSet,baseThickness - (useCutout ? - (-baseThickness*2):0)]) linear_extrude(height = shelfSupportHeight+rimHeight+1) circle(r = itemDiameter/2, $fn=50);
     }
     //brackets
     bracketSize = min(totalHeight-baseThickness-shelfSupportHeight, itemDiameter/2);


### PR DESCRIPTION
Added option to use cutout for holding round items that are wider at the top

Added offset parameter for the ability to offset the holding position from the back wall

![image](https://github.com/user-attachments/assets/5049d74b-9cda-47fa-aa4b-080e6785f46e)

Also fixing an issue with coplanar surfaces when using a baseThickness of 0 (which might be intersting as it provides the slimmest possible base for minimal filament use). Fix solves the issue for both cutOut = false and cutOut = true.

| Master | This PR |
| ------------- | ------------- |
| ![image](https://github.com/user-attachments/assets/23de2348-c719-4e25-a23b-da2499fbb016) | ![image](https://github.com/user-attachments/assets/b5912a00-ab0c-4252-adc3-a3abc8fd42ee)  |



