### PR TITLE
Adding subtractedSlots parameter to Underware Item Holder

### DIFF
--- a/Underware/Underware_Item_Holder.scad
+++ b/Underware/Underware_Item_Holder.scad
@@ -112,6 +112,8 @@ onRampHalfOffset = true;
 Slot_From_Top = true;
 //Distance between Multiconnect slots on the back (25mm is standard for MultiBoard)
 distanceBetweenSlots = 25;
+//Reduce the number of slots
+subtractedSlots = 0;
 //QuickRelease removes the small indent in the top of the slots that lock the part into place
 slotQuickRelease = false;
 //Dimple scale tweaks the size of the dimple in the slot for printers that need a larger dimple to print correctly
@@ -217,7 +219,7 @@ module multiconnectBack(backWidth, backHeight, distanceBetweenSlots, slotStopFro
 {
     //slot count calculates how many slots can fit on the back. Based on internal width for buffer. 
     //slot width needs to be at least the distance between slot for at least 1 slot to generate
-    let (backWidth = max(backWidth,distanceBetweenSlots), backHeight = max(backHeight, 25),slotCount = floor(backWidth/distanceBetweenSlots), backThickness = 6.5){
+    let (backWidth = max(backWidth,distanceBetweenSlots), backHeight = max(backHeight, 25),slotCount = floor(backWidth/distanceBetweenSlots) - subtractedSlots, backThickness = 6.5){
         difference() {
             translate(v = [0,-backThickness,0]) 
             cuboid(size = [backWidth,backThickness,backHeight], rounding=edgeRounding, except_edges=BACK, anchor=FRONT+LEFT+BOT);


### PR DESCRIPTION
Adding option to reduce the number of mounting slots generated.

![addingSubtractedSlotsParameter](https://github.com/user-attachments/assets/53ddcfba-d7bf-4b47-8cad-afab6ac68b5e)

This was useful when I needed to have the centers of 2 item holders of different width aligned. One item holder would have 4 slots and the other 5 which would make it impossible to align the centers. Reducing the wider item holder's slot count by 1 fixed this.