### PR TITLE
Add support for GOEWS cleats/bolts to the vertical item holder

### DIFF
--- a/VerticalMountingSeries/VerticalItemHolder.scad
+++ b/VerticalMountingSeries/VerticalItemHolder.scad
@@ -274,14 +274,14 @@ module makebackPlate(backWidth, backHeight, distanceBetweenSlots, backThickness,
                 for (slotNum = [0:1:slotCount-1]) {
                     translate(v = [distanceBetweenSlots/2+(backWidth/distanceBetweenSlots-slotCount)*distanceBetweenSlots/2+slotNum*distanceBetweenSlots, 0, backHeight + 0.46 - GOEWS_Cleat_height_from_top_of_back + 11.24]) {
                         rotate([90, 0, 0])
-                            cylinder(h = backThickness + 0.1, r = 5.76, $fn = 256);
+                            cylinder(h = backThickness + 0.1, r = 7, $fn = 256);
                     }
                 }
                 // Remove back plate cut outs for screw heads
                 for (slotNum = [0:1:slotCount-1]) {
                     translate(v = [distanceBetweenSlots/2+(backWidth/distanceBetweenSlots-slotCount)*distanceBetweenSlots/2+slotNum*distanceBetweenSlots, -4, backHeight + 0.46 - GOEWS_Cleat_height_from_top_of_back + 11.24]) {
                         rotate([-90, 0, 0])
-                            cylinder(h = 4.1, r = 9.675, $fn = 256);
+                            cylinder(h = 4.1, r = 10, $fn = 256);
                     }
                 }
             }

--- a/VerticalMountingSeries/VerticalItemHolder.scad
+++ b/VerticalMountingSeries/VerticalItemHolder.scad
@@ -39,6 +39,9 @@ include <BOSL2/walls.scad>
 //Multipoint in Beta - Please share feedback! How do you intend to mount the item holder to a surface such as Multipoint connections or DavidD's Multiconnect?
 Connection_Type = "GOEWS"; // [Multipoint, Multiconnect, GOEWS]
 
+/*[GOEWS Customization]*/
+GOEWS_Cleat_height_from_top_of_back = 11.24;
+
 /* [Internal Dimensions] */
 //Height (in mm) from the top of the back to the base of the internal floor
 internalHeight = 50.0; //.1
@@ -130,9 +133,6 @@ onRampEnabled = true;
 On_Ramp_Every_X_Slots = 1;
 //Distance from the back of the item holder to where the multiconnect stops (i.e., where the dimple is) (by mm)
 Multiconnect_Stop_Distance_From_Back = 13;
-
-/*[GOEWS Customization]*/
-GOEWS_Cleat_height_from_top_of_back = 11.24;
 
 /* [Hidden] */
 debugCutoutTool = false;

--- a/VerticalMountingSeries/VerticalItemHolder.scad
+++ b/VerticalMountingSeries/VerticalItemHolder.scad
@@ -40,7 +40,8 @@ include <BOSL2/walls.scad>
 Connection_Type = "GOEWS"; // [Multipoint, Multiconnect, GOEWS]
 
 /*[GOEWS Customization]*/
-GOEWS_Cleat_height_from_top_of_back = 11.24;
+GOEWS_Cleat_position = "normal"; // [normal, top, bottom, custom]
+GOEWS_Cleat_custom_height_from_top_of_back = 11.24;
 
 /* [Internal Dimensions] */
 //Height (in mm) from the top of the back to the base of the internal floor
@@ -179,8 +180,7 @@ union(){
             backWidth = totalWidth, 
             backHeight = totalHeight, 
             distanceBetweenSlots = 42,
-            backThickness=7,
-            slotStopFromBack = 11.24
+            backThickness=7
         );
     }
 }
@@ -256,6 +256,8 @@ module makebackPlate(backWidth, backHeight, distanceBetweenSlots, backThickness,
             }
         } else {
             // GOEWS
+            GOEWS_Cleat_custom_height_from_top_of_back = (GOEWS_Cleat_position == "normal") ? 11.24 : (GOEWS_Cleat_position == "top") ? 0 :  (GOEWS_Cleat_position == "bottom") ? backHeight - 13.15 : GOEWS_Cleat_custom_height_from_top_of_back;
+            
             difference() {
                 union() {
                     // Back plate
@@ -265,21 +267,21 @@ module makebackPlate(backWidth, backHeight, distanceBetweenSlots, backThickness,
                     //Note: I kept doing math until it looked right. It's possible this can be simplified.
                     // Add cleats
                     for (slotNum = [0:1:slotCount-1]) {
-                        translate(v = [distanceBetweenSlots/2+(backWidth/distanceBetweenSlots-slotCount)*distanceBetweenSlots/2+slotNum*distanceBetweenSlots,-1 * backThickness,backHeight-GOEWS_Cleat_height_from_top_of_back]) {
+                        translate(v = [distanceBetweenSlots/2+(backWidth/distanceBetweenSlots-slotCount)*distanceBetweenSlots/2+slotNum*distanceBetweenSlots,-1 * backThickness,backHeight-GOEWS_Cleat_custom_height_from_top_of_back]) {
                             GOEWSCleatTool(totalHeight);
                         }
                     }
                 };
                 // Remove back plate cut outs for screw threads
                 for (slotNum = [0:1:slotCount-1]) {
-                    translate(v = [distanceBetweenSlots/2+(backWidth/distanceBetweenSlots-slotCount)*distanceBetweenSlots/2+slotNum*distanceBetweenSlots, 0, backHeight + 0.46 - GOEWS_Cleat_height_from_top_of_back + 11.24]) {
+                    translate(v = [distanceBetweenSlots/2+(backWidth/distanceBetweenSlots-slotCount)*distanceBetweenSlots/2+slotNum*distanceBetweenSlots, 0, backHeight + 0.46 - GOEWS_Cleat_custom_height_from_top_of_back + 11.24]) {
                         rotate([90, 0, 0])
                             cylinder(h = backThickness + 0.1, r = 7, $fn = 256);
                     }
                 }
                 // Remove back plate cut outs for screw heads
                 for (slotNum = [0:1:slotCount-1]) {
-                    translate(v = [distanceBetweenSlots/2+(backWidth/distanceBetweenSlots-slotCount)*distanceBetweenSlots/2+slotNum*distanceBetweenSlots, -4, backHeight + 0.46 - GOEWS_Cleat_height_from_top_of_back + 11.24]) {
+                    translate(v = [distanceBetweenSlots/2+(backWidth/distanceBetweenSlots-slotCount)*distanceBetweenSlots/2+slotNum*distanceBetweenSlots, -4, backHeight + 0.46 - GOEWS_Cleat_custom_height_from_top_of_back + 11.24]) {
                         rotate([-90, 0, 0])
                             cylinder(h = 4.1, r = 10, $fn = 256);
                     }

--- a/VerticalMountingSeries/VerticalItemHolder.scad
+++ b/VerticalMountingSeries/VerticalItemHolder.scad
@@ -21,7 +21,8 @@ Change Log:
 - 2025-01-02
     - Multipoint mounting
     - Thanks @SnazzyGreenWarrior!
-
+- 2025-01-16
+    - Added GOEWS cleats option (@andrew_3d)
 
 Notes:
 - Slot test fit - For a slot test fit, set the following parameters
@@ -36,7 +37,7 @@ include <BOSL2/walls.scad>
 
 /* [Beta Feature - Slot Type] */
 //Multipoint in Beta - Please share feedback! How do you intend to mount the item holder to a surface such as Multipoint connections or DavidD's Multiconnect?
-Connection_Type = "Multiconnect"; // [Multipoint, Multiconnect]
+Connection_Type = "GOEWS"; // [Multipoint, Multiconnect, GOEWS]
 
 /* [Internal Dimensions] */
 //Height (in mm) from the top of the back to the base of the internal floor
@@ -130,6 +131,9 @@ On_Ramp_Every_X_Slots = 1;
 //Distance from the back of the item holder to where the multiconnect stops (i.e., where the dimple is) (by mm)
 Multiconnect_Stop_Distance_From_Back = 13;
 
+/*[GOEWS Customization]*/
+GOEWS_Cleat_height_from_top_of_back = 11.24;
+
 /* [Hidden] */
 debugCutoutTool = false;
 
@@ -168,6 +172,16 @@ union(){
             backHeight = totalHeight, 
             distanceBetweenSlots = distanceBetweenSlots,
             backThickness=6.5);
+    }
+    if(Connection_Type == "GOEWS"){
+        translate([-max(totalWidth,distanceBetweenSlots)/2,0.01,-baseThickness])
+        makebackPlate(
+            backWidth = totalWidth, 
+            backHeight = totalHeight, 
+            distanceBetweenSlots = 42,
+            backThickness=7,
+            slotStopFromBack = 11.24
+        );
     }
 }
 
@@ -223,23 +237,80 @@ module makebackPlate(backWidth, backHeight, distanceBetweenSlots, backThickness,
     //slot count calculates how many slots can fit on the back. Based on internal width for buffer. 
     //slot width needs to be at least the distance between slot for at least 1 slot to generate
     let (backWidth = max(backWidth,distanceBetweenSlots), backHeight = max(backHeight, 25),slotCount = floor(backWidth/distanceBetweenSlots)- subtractedSlots){
-        difference() {
-            translate(v = [0,-backThickness,0]) 
-            cuboid(size = [backWidth,backThickness,backHeight], rounding=edgeRounding, except_edges=BACK, anchor=FRONT+LEFT+BOT);
-            //Loop through slots and center on the item
-            //Note: I kept doing math until it looked right. It's possible this can be simplified.
-            for (slotNum = [0:1:slotCount-1]) {
-                translate(v = [distanceBetweenSlots/2+(backWidth/distanceBetweenSlots-slotCount)*distanceBetweenSlots/2+slotNum*distanceBetweenSlots,-2.35+slotDepthMicroadjustment,backHeight-Multiconnect_Stop_Distance_From_Back]) {
-                    if(Connection_Type == "Multipoint"){
-                        multiPointSlotTool(totalHeight);
+        if(Connection_Type != "GOEWS"){
+            difference() {
+                translate(v = [0,-backThickness,0]) 
+                cuboid(size = [backWidth,backThickness,backHeight], rounding=edgeRounding, except_edges=BACK, anchor=FRONT+LEFT+BOT);
+                //Loop through slots and center on the item
+                //Note: I kept doing math until it looked right. It's possible this can be simplified.
+                for (slotNum = [0:1:slotCount-1]) {
+                    translate(v = [distanceBetweenSlots/2+(backWidth/distanceBetweenSlots-slotCount)*distanceBetweenSlots/2+slotNum*distanceBetweenSlots,-2.35+slotDepthMicroadjustment,backHeight-Multiconnect_Stop_Distance_From_Back]) {
+                        if(Connection_Type == "Multipoint"){
+                            multiPointSlotTool(totalHeight);
+                        }
+                        if(Connection_Type == "Multiconnect"){
+                            multiConnectSlotTool(totalHeight);
+                        }
                     }
-                    if(Connection_Type == "Multiconnect"){
-                        multiConnectSlotTool(totalHeight);
+                }
+            }
+        } else {
+            // GOEWS
+            difference() {
+                union() {
+                    // Back plate
+                    translate(v = [0,-backThickness,0]) 
+                    cuboid(size = [backWidth,backThickness,backHeight], rounding=edgeRounding, except_edges=BACK, anchor=FRONT+LEFT+BOT);
+                    //Loop through slots and center on the item
+                    //Note: I kept doing math until it looked right. It's possible this can be simplified.
+                    // Add cleats
+                    for (slotNum = [0:1:slotCount-1]) {
+                        translate(v = [distanceBetweenSlots/2+(backWidth/distanceBetweenSlots-slotCount)*distanceBetweenSlots/2+slotNum*distanceBetweenSlots,-1 * backThickness,backHeight-GOEWS_Cleat_height_from_top_of_back]) {
+                            GOEWSCleatTool(totalHeight);
+                        }
+                    }
+                };
+                // Remove back plate cut outs for screw threads
+                for (slotNum = [0:1:slotCount-1]) {
+                    translate(v = [distanceBetweenSlots/2+(backWidth/distanceBetweenSlots-slotCount)*distanceBetweenSlots/2+slotNum*distanceBetweenSlots, 0, backHeight + 0.46 - GOEWS_Cleat_height_from_top_of_back + 11.24]) {
+                        rotate([90, 0, 0])
+                            cylinder(h = backThickness + 0.1, r = 5.76, $fn = 256);
+                    }
+                }
+                // Remove back plate cut outs for screw heads
+                for (slotNum = [0:1:slotCount-1]) {
+                    translate(v = [distanceBetweenSlots/2+(backWidth/distanceBetweenSlots-slotCount)*distanceBetweenSlots/2+slotNum*distanceBetweenSlots, -4, backHeight + 0.46 - GOEWS_Cleat_height_from_top_of_back + 11.24]) {
+                        rotate([-90, 0, 0])
+                            cylinder(h = 4.1, r = 9.675, $fn = 256);
                     }
                 }
             }
         }
     }   
+}
+
+//Create GOEWS cleats
+module GOEWSCleatTool(totalHeight) {
+    difference() {
+        // main profile
+        rotate(a = [180,0,0]) 
+            linear_extrude(height = 13.15) 
+                let (cleatProfile = [[0,0],[15.1,0],[17.6,2.5],[15.1,5],[0,5]])
+                union(){
+                    polygon(points = cleatProfile);
+                    mirror([1,0,0])
+                        polygon(points = cleatProfile);
+                };
+        // angled slice off bottom
+        translate([-17.6, -8, -26.3])
+            rotate([45, 0, 0])
+                translate([0, 5, 0])
+                    cube([35.2, 10, 15]);
+        // cutout
+        translate([0, -0.005, 2.964])
+            rotate([90, 0, 0])
+                cylinder(h = 6, r = 9.5, $fn = 256);
+    }
 }
 
 //Create Slot Tool


### PR DESCRIPTION
A first attempt at adding in support for GOEWS mounting on the vertical item holder. The other slot types should still work but probably need thorough testing by someone who knows what they're doing.
![item holder](https://github.com/user-attachments/assets/ad188446-ca4c-45f5-bc3b-0412a1e4791c)
