### PR TITLE
Add option to round top edges

### DIFF
--- a/VerticalMountingSeries/MulticonnectHook.scad
+++ b/VerticalMountingSeries/MulticonnectHook.scad
@@ -14,7 +14,9 @@ hookLipHeight = 4;
 hookLipThickness = 3;
 hookBottomThickness = 5;
 backHeight = 35;
-topEdgesRadius = 0;
+hookRadius = 0;
+backRadius = 0;
+
 
 /*[Slot Customization]*/
 //Distance between Multiconnect slots on the back (25mm is standard for MultiBoard)
@@ -44,10 +46,10 @@ union(){
         multiconnectBack(backWidth = backWidth, backHeight = backHeight, distanceBetweenSlots = distanceBetweenSlots);
     //hook base
     translate(v = [-hookWidth/2,0,0]) 
-        topRoundedCube(size = [hookWidth,hookInternalDepth+hookLipThickness,hookBottomThickness]);
+        topRoundedCube(size = [hookWidth,hookInternalDepth+hookLipThickness,hookBottomThickness], r = hookRadius);
     //hook lip
     translate(v = [-hookWidth/2,hookInternalDepth,0]) 
-        topRoundedCube(size = [hookWidth,hookLipThickness,hookLipHeight+hookBottomThickness]);
+        topRoundedCube(size = [hookWidth,hookLipThickness,hookLipHeight+hookBottomThickness], r = hookRadius);
 }
 
 //BEGIN MODULES
@@ -58,7 +60,7 @@ module multiconnectBack(backWidth, backHeight, distanceBetweenSlots)
     //slot width needs to be at least the distance between slot for at least 1 slot to generate
     let (backWidth = max(backWidth,distanceBetweenSlots), backHeight = max(backHeight, 25),slotCount = floor(backWidth/distanceBetweenSlots), backThickness = 6.5){
         difference() {
-            translate(v = [0,-backThickness,0]) topRoundedCube(size = [backWidth,backThickness,backHeight]);
+            translate(v = [0,-backThickness,0]) topRoundedCube(size = [backWidth,backThickness,backHeight], r = backRadius);
             //Loop through slots and center on the item
             //Note: I kept doing math until it looked right. It's possible this can be simplified.
             for (slotNum = [0:1:slotCount-1]) {
@@ -105,9 +107,9 @@ module multiconnectBack(backWidth, backHeight, distanceBetweenSlots)
     }
 }
 
-module topRoundedCube(size) {
+module topRoundedCube(size, r) {
     diff()
         cube(size = size)
             edge_mask([TOP+LEFT, TOP+RIGHT])
-            rounding_edge_mask(l=size[1],r=topEdgesRadius,$fn=subDivTopEdges);
+            rounding_edge_mask(l=size[1],r=r,$fn=subDivTopEdges);
 }

--- a/VerticalMountingSeries/MulticonnectHook.scad
+++ b/VerticalMountingSeries/MulticonnectHook.scad
@@ -3,6 +3,8 @@ Credit to @David D on Printables and Jonathan at Keep Making for Multiconnect an
 Licensed Creative Commons 4.0 Attribution Non-Commercial Sharable with Attribution
 */
 
+include <BOSL2/std.scad>
+
 /* [Standard Parameters] */
 hookWidth = 25;
 hookInternalDepth = 25;
@@ -12,6 +14,7 @@ hookLipHeight = 4;
 hookLipThickness = 3;
 hookBottomThickness = 5;
 backHeight = 35;
+topEdgesRadius = 0;
 
 /*[Slot Customization]*/
 //Distance between Multiconnect slots on the back (25mm is standard for MultiBoard)
@@ -32,6 +35,7 @@ onRampEveryXSlots = 1;
 
 /*[Hidden]*/
 backWidth = max(distanceBetweenSlots,hookWidth);
+subDivTopEdges=66;
 
 //Hook
 union(){
@@ -40,10 +44,10 @@ union(){
         multiconnectBack(backWidth = backWidth, backHeight = backHeight, distanceBetweenSlots = distanceBetweenSlots);
     //hook base
     translate(v = [-hookWidth/2,0,0]) 
-        cube(size = [hookWidth,hookInternalDepth+hookLipThickness,hookBottomThickness]);
+        topRoundedCube(size = [hookWidth,hookInternalDepth+hookLipThickness,hookBottomThickness]);
     //hook lip
     translate(v = [-hookWidth/2,hookInternalDepth,0]) 
-        cube(size = [hookWidth,hookLipThickness,hookLipHeight+hookBottomThickness]);
+        topRoundedCube(size = [hookWidth,hookLipThickness,hookLipHeight+hookBottomThickness]);
 }
 
 //BEGIN MODULES
@@ -54,7 +58,7 @@ module multiconnectBack(backWidth, backHeight, distanceBetweenSlots)
     //slot width needs to be at least the distance between slot for at least 1 slot to generate
     let (backWidth = max(backWidth,distanceBetweenSlots), backHeight = max(backHeight, 25),slotCount = floor(backWidth/distanceBetweenSlots), backThickness = 6.5){
         difference() {
-            translate(v = [0,-backThickness,0]) cube(size = [backWidth,backThickness,backHeight]);
+            translate(v = [0,-backThickness,0]) topRoundedCube(size = [backWidth,backThickness,backHeight]);
             //Loop through slots and center on the item
             //Note: I kept doing math until it looked right. It's possible this can be simplified.
             for (slotNum = [0:1:slotCount-1]) {
@@ -99,4 +103,11 @@ module multiconnectBack(backWidth, backHeight, distanceBetweenSlots)
                         polygon(points = [[0,0],[0,1.5],[1.5,0]]);
         }
     }
+}
+
+module topRoundedCube(size) {
+    diff()
+        cube(size = size)
+            edge_mask([TOP+LEFT, TOP+RIGHT])
+            rounding_edge_mask(l=size[1],r=topEdgesRadius,$fn=subDivTopEdges);
 }


### PR DESCRIPTION
I wanted to smooth out the look of the hook, and also have an option for round objects, roll of tapes for example.

This is my first time woking with OpenSCAD, I hope what I did makes sense. It's a fairly small change.

New options for back and hook (which also applies to lip) radius

Default options exept both radius set to 3, just smoothing out the looks
![MulticonnectHook-Radius-3](https://github.com/user-attachments/assets/e67e89f1-c7b1-46cb-b955-790c0cd2c908)

both radius set to 10, with bottom thickness set to 10, for a semi circle hook
![MulticonnectHook-Radius-10](https://github.com/user-attachments/assets/503093e5-94c2-4826-82e2-539724f5eb03)
