### PR TITLE
Make it possible to override the default location of OpenSCAD

### DIFF
--- a/Underware/UnderwareBuilder.py
+++ b/Underware/UnderwareBuilder.py
@@ -7,7 +7,7 @@ import yaml
 import time
 
 # Specify the path to openscad.exe
-openscad_path = 'C:/Program Files/OpenSCAD (Nightly)/openscad.exe'
+openscad_path = os.environ.get('OPENSCAD', 'C:/Program Files/OpenSCAD (Nightly)/openscad.exe')
 
 # Check if openscad.exe exists
 if not os.path.isfile(openscad_path):


### PR DESCRIPTION
Can be used like this:
```
export OPENSCAD=~/apps/OpenSCAD-2024.11.18.ai21237-x86_64.AppImage
```

or like this:
```
OPENSCAD=~/apps/OpenSCAD-2024.11.18.ai21237-x86_64.AppImage python UnderwareBuilder.py
```