### PR TITLE
Add a nix flake to handle dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Web version is available here:
 ## Contributing
 
 We use [BOSL2](https://github.com/BelfrySCAD/BOSL2) as a dependency and needs to be install accordingly.
+If you have [nix](https://nixos.org/) installed with flakes activated, then everything will be setup for you with `nix develop`.
 
 ## License
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,78 @@
+{
+  "nodes": {
+    "bosl2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1745612424,
+        "narHash": "sha256-zW4Oj0SmO1gVJ8Gqu+KRNLlx+sWaELIKEFbr2IW9CHU=",
+        "owner": "BelfrySCAD",
+        "repo": "BOSL2",
+        "rev": "d651dea1ffa543ad0a18367ff7c846010d1b312a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "BelfrySCAD",
+        "repo": "BOSL2",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1745487689,
+        "narHash": "sha256-FQoi3R0NjQeBAsEOo49b5tbDPcJSMWc3QhhaIi9eddw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "5630cf13cceac06cefe9fc607e8dfa8fb342dde3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "bosl2": "bosl2",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,30 @@
+{
+  description = "Quack works";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
+    bosl2 = {
+      url = "github:BelfrySCAD/BOSL2";
+      flake = false;
+    };
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils, bosl2, ... }@inputs:
+    (flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+        bosl2-lib = pkgs.runCommand "bosl2-lib" { } ''
+          mkdir -p $out/
+          ln -s ${bosl2} $out/BOSL2
+        '';
+      in
+      {
+        devShells.default = pkgs.mkShell {
+          packages = [
+            pkgs.openscad
+          ];
+          OPENSCADPATH = "${bosl2-lib}";
+        };
+      }));
+}


### PR DESCRIPTION
The variable `OPENSCADPATH` is used by openscad when looking for dependencies.
I used that fact to setup a shell via [`nix`](https://nixos.org/) to have `BOSL2` setup automatically.

A strong feature of nix is determinism. Setting up the shell in which you develop with it virtually guaranties that everyone has the same version of tools.

Since I am using NixOS myself, I kind of needed to do it anyway in order to start coding the hooks (cf #38) so why not contribute it for everyone to enjoy ?