### PR TITLE
Underware Transition Channel - Rise Offset

### DIFF
--- a/Underware/Underware_Transition_Channel.scad
+++ b/Underware/Underware_Transition_Channel.scad
@@ -22,15 +22,15 @@ Base_Top_or_Both = "Both"; // [Base, Top, Both]
 
 /*[Channel Size]*/
 //Width (X axis) of channel in units. Default unit is 25mm
-Channel_Width_in_Units_1 = 3;  // Ensure this is an integer
+Channel_Width_in_Units_1 = 2;  // Ensure this is an integer
 //Width (X axis) of channel in units. Default unit is 25mm
 Channel_Width_in_Units_2 = 1;  // Ensure this is an integer
 //Height (Z axis) inside the channel (in mm)
-Channel_Internal_Height_1 = 34; //[12:6:72]
+Channel_Internal_Height_1 = 18; //[12:6:72]
 //Height (Z axis) inside the channel (in mm)
 Channel_Internal_Height_2 = 12; //[12:6:72]
 //Length (Y axis) of channel in units. Default unit is 25mm
-Channel_Length_Units = 4; 
+Channel_Length_Units = 3; 
 //The lateral distance of the rising portion of the channel
 Rise_Distance = 25; //[12.5:12.5:100]
 //The offset from center of the rising portion of the channel (0 == centered)

--- a/Underware/Underware_Transition_Channel.scad
+++ b/Underware/Underware_Transition_Channel.scad
@@ -22,17 +22,19 @@ Base_Top_or_Both = "Both"; // [Base, Top, Both]
 
 /*[Channel Size]*/
 //Width (X axis) of channel in units. Default unit is 25mm
-Channel_Width_in_Units_1 = 2;  // Ensure this is an integer
+Channel_Width_in_Units_1 = 3;  // Ensure this is an integer
 //Width (X axis) of channel in units. Default unit is 25mm
 Channel_Width_in_Units_2 = 1;  // Ensure this is an integer
 //Height (Z axis) inside the channel (in mm)
-Channel_Internal_Height_1 = 18; //[12:6:72]
+Channel_Internal_Height_1 = 34; //[12:6:72]
 //Height (Z axis) inside the channel (in mm)
 Channel_Internal_Height_2 = 12; //[12:6:72]
 //Length (Y axis) of channel in units. Default unit is 25mm
-Channel_Length_Units = 3; 
+Channel_Length_Units = 4; 
 //The lateral distance of the rising portion of the channel
 Rise_Distance = 25; //[12.5:12.5:100]
+//The offset from center of the rising portion of the channel (0 == centered)
+Rise_Offset = 0; //[-100:12.5:100]
 
 /*[Mounting Options]*/
 //How do you intend to mount the channels to a surface such as Honeycomb Storage Wall or Multiboard? See options at https://handsonkatie.com/underware-2-0-the-made-to-measure-collection/
@@ -139,7 +141,7 @@ module straightHeightChangeChannelTop(lengthMM, widthMM1, widthMM2, heightMM1 = 
                 left(Channel_Width_in_Units_2 % 2 == 1 ? 12.5 :  0, newTopProfileFull(heightMM = Channel_Internal_Height_2, totalWidth = widthMM2, topThickness = topThickness)),
                 left(Channel_Width_in_Units_2 % 2 == 1 ? 12.5 :  0, newTopProfileFull(heightMM = Channel_Internal_Height_2, totalWidth = widthMM2, topThickness = topThickness))
             ],
-            z=[0,lengthMM/2-Rise_Distance/2,lengthMM/2+Rise_Distance/2,lengthMM],
+            z=[0,lengthMM/2-Rise_Distance/2+Rise_Offset,lengthMM/2+Rise_Distance/2+Rise_Offset,lengthMM],
             slices = 0
             );
     children();
@@ -162,7 +164,7 @@ module straightChangeChannelBase(lengthMM, widthMM1, widthMM2,anchor, spin, orie
                 left(Channel_Width_in_Units_2 % 2 == 1 ? 12.5 :  0, newBaseProfileFull(totalWidth = widthMM2)),
                 left(Channel_Width_in_Units_2 % 2 == 1 ? 12.5 :  0, newBaseProfileFull(totalWidth = widthMM2))
             ],
-            z=[0,lengthMM/2-Rise_Distance/2,lengthMM/2+Rise_Distance/2,lengthMM],
+            z=[0,lengthMM/2-Rise_Distance/2+Rise_Offset,lengthMM/2+Rise_Distance/2+Rise_Offset,lengthMM],
             slices = 0
             );
         tag("holes")  back(lengthMM/2-Grid_Size/2)  left(Channel_Width_in_Units_1 % 2 == 1 ? 12.5 :  0)


### PR DESCRIPTION
By default, the riser is centered.  I use the transition segments to cover permanent connections.  I added Riser Offset to allow control of where the riser is positioned.  Allowing larger/smaller strait segments on either side.

<img width="836" alt="image" src="https://github.com/user-attachments/assets/c30406ae-b2f7-4bfc-8142-9e08e383b133" />
<img width="851" alt="image" src="https://github.com/user-attachments/assets/7cbed763-04f1-4154-9f6a-23654c9325c8" />
<img width="1045" alt="image" src="https://github.com/user-attachments/assets/ab157049-c0bd-4772-9d9c-c975b1e430ee" />
<img width="1092" alt="image" src="https://github.com/user-attachments/assets/cc88565f-2491-4ae0-bb83-a53725dda70d" />

