### PR TITLE
Update multiconnect slot modules with multiconnect v2

### DIFF
--- a/Modules/multiconnectSlotDesign.scad
+++ b/Modules/multiconnectSlotDesign.scad
@@ -6,6 +6,8 @@ totalWidth = 50;
 totalHeight = 75;
 
 /*[Slot Customization]*/
+// Version of multiconnect (dimple or snap)
+multiConnectVersion = "v2"; // [v1, v2]
 //Distance between Multiconnect slots on the back (25mm is standard for MultiBoard)
 distanceBetweenSlots = 25;
 //QuickRelease removes the small indent in the top of the slots that lock the part into place
@@ -57,12 +59,34 @@ module multiconnectBack(backWidth, backHeight, distanceBetweenSlots)
                 //long slot
                 translate(v = [0,0,0]) 
                     rotate(a = [180,0,0]) 
-                    linear_extrude(height = totalHeight+1) 
-                        union(){
-                            polygon(points = slotProfile);
-                            mirror([1,0,0])
+                    union(){
+                        difference() {
+                            // Main half slot
+                            linear_extrude(height = totalHeight+1) 
                                 polygon(points = slotProfile);
-                        }
+                            
+                            // Snap cutout
+                            if (slotQuickRelease == false && multiConnectVersion == "v2")
+                                translate(v= [10.15,0,0])
+                                rotate(a= [-90,0,0])
+                                linear_extrude(height = 5)  // match slot height (5mm)
+                                    polygon(points = [[0,0],[-0.4,0],[0,-8]]);  // triangle polygon with multiconnect v2 specs
+                            }
+
+                        mirror([1,0,0])
+                            difference() {
+                                // Main half slot
+                                linear_extrude(height = totalHeight+1) 
+                                    polygon(points = slotProfile);
+                                
+                                // Snap cutout
+                                if (slotQuickRelease == false && multiConnectVersion == "v2")
+                                    translate(v= [10.15,0,0])
+                                    rotate(a= [-90,0,0])
+                                    linear_extrude(height = 5)  // match slot height (5mm)
+                                        polygon(points = [[0,0],[-0.4,0],[0,-8]]);  // triangle polygon with multiconnect v2 spec
+                            }
+                    }
                 //on-ramp
                 if(onRampEnabled)
                     for(y = [1:onRampEveryXSlots:totalHeight/distanceBetweenSlots])
@@ -71,7 +95,7 @@ module multiconnectBack(backWidth, backHeight, distanceBetweenSlots)
                                 color(c = "orange") cylinder(h = 5, r1 = 12, r2 = 10.15);
             }
             //dimple
-            if (slotQuickRelease == false)
+            if (slotQuickRelease == false && multiConnectVersion == "v1")
                 scale(v = dimpleScale) 
                 rotate(a = [90,0,0,]) 
                     rotate_extrude($fn=50) 

--- a/Underware/UnderwareInProgress/hooksAndGroves.scad
+++ b/Underware/UnderwareInProgress/hooksAndGroves.scad
@@ -43,6 +43,8 @@ Tile_Size = 28;
 Tile_Thickness = 6.8;
 
 /*[Advanced - Slot Customization]*/
+// Version of multiconnect (dimple or snap)
+multiConnectVersion = "v2"; // [v1, v2]
 //Offset the multiconnect on-ramps to be between grid slots rather than on the slot
 onRampHalfOffset = true;
 //Change slot orientation, when enabled slots to come from the top of the back, when disabled slots come from the bottom
@@ -279,12 +281,34 @@ module multiconnectBack(backWidth, backHeight, distanceBetweenSlots, slotStopFro
                 //long slot
                 translate(v = [0,0,0]) 
                     rotate(a = [180,0,0]) 
-                    linear_extrude(height = totalDepth+1) 
-                        union(){
-                            polygon(points = slotProfile);
-                            mirror([1,0,0])
+                    union(){
+                        difference() {
+                            // Main half slot
+                            linear_extrude(height = totalDepth+1) 
                                 polygon(points = slotProfile);
-                        }
+                            
+                            // Snap cutout
+                            if (slotQuickRelease == false && multiConnectVersion == "v2")
+                                translate(v= [10.15,0,0])
+                                rotate(a= [-90,0,0])
+                                linear_extrude(height = 5)  // match slot height (5mm)
+                                    polygon(points = [[0,0],[-0.4,0],[0,-8]]);  // triangle polygon with multiconnect v2 specs
+                            }
+
+                        mirror([1,0,0])
+                            difference() {
+                                // Main half slot
+                                linear_extrude(height = totalDepth+1) 
+                                    polygon(points = slotProfile);
+                                
+                                // Snap cutout
+                                if (slotQuickRelease == false && multiConnectVersion == "v2")
+                                    translate(v= [10.15,0,0])
+                                    rotate(a= [-90,0,0])
+                                    linear_extrude(height = 5)  // match slot height (5mm)
+                                        polygon(points = [[0,0],[-0.4,0],[0,-8]]);  // triangle polygon with multiconnect v2 spec
+                            }
+                    }
                 //on-ramp
                 if(onRampEnabled)
                     for(y = [1:onRampEveryXSlots:totalDepth/distanceBetweenSlots])
@@ -294,7 +318,7 @@ module multiconnectBack(backWidth, backHeight, distanceBetweenSlots, slotStopFro
                                 cylinder(h = 5, r1 = 12, r2 = 10.15);
             }
             //dimple
-            if (slotQuickRelease == false)
+            if (slotQuickRelease == false && multiConnectVersion == "v1")
                 scale(v = dimpleScale) 
                 rotate(a = [90,0,0,]) 
                     rotate_extrude($fn=50) 

--- a/Underware/Underware_Cable_Loop_holder.scad
+++ b/Underware/Underware_Cable_Loop_holder.scad
@@ -36,6 +36,8 @@ verticalResolution = 6;
 edgeRounding = 0.5; // [0:0.1:2]
 
 /*[Slot Customization]*/
+// Version of multiconnect (dimple or snap)
+multiConnectVersion = "v2"; // [v1, v2]
 onRampHalfOffset = true;
 //Distance between Multiconnect slots on the back (25mm is standard for MultiBoard)
 distanceBetweenSlots = 25;
@@ -208,12 +210,34 @@ module multiConnectSlotTool(totalHeight) {
             //long slot
             translate(v = [0,0,0]) 
                 rotate(a = [180,0,0]) 
-                linear_extrude(height = totalHeight+1) 
-                    union(){
-                        polygon(points = slotProfile);
-                        mirror([1,0,0])
+                union(){
+                    difference() {
+                        // Main half slot
+                        linear_extrude(height = totalHeight+1) 
                             polygon(points = slotProfile);
-                    }
+                        
+                        // Snap cutout
+                        if (slotQuickRelease == false && multiConnectVersion == "v2")
+                            translate(v= [10.15,0,0])
+                            rotate(a= [-90,0,0])
+                            linear_extrude(height = 5)  // match slot height (5mm)
+                                polygon(points = [[0,0],[-0.4,0],[0,-8]]);  // triangle polygon with multiconnect v2 specs
+                        }
+
+                    mirror([1,0,0])
+                        difference() {
+                            // Main half slot
+                            linear_extrude(height = totalHeight+1) 
+                                polygon(points = slotProfile);
+                            
+                            // Snap cutout
+                            if (slotQuickRelease == false && multiConnectVersion == "v2")
+                                translate(v= [10.15,0,0])
+                                rotate(a= [-90,0,0])
+                                linear_extrude(height = 5)  // match slot height (5mm)
+                                    polygon(points = [[0,0],[-0.4,0],[0,-8]]);  // triangle polygon with multiconnect v2 spec
+                        }
+                }
             //on-ramp
             if(onRampEnabled)
                 for(y = [1:onRampEveryXSlots:totalHeight/distanceBetweenSlots])
@@ -223,7 +247,7 @@ module multiConnectSlotTool(totalHeight) {
                             cylinder(h = 5, r1 = 12, r2 = 10.15);
         }
         //dimple
-        if (slotQuickRelease == false)
+        if (slotQuickRelease == false && multiConnectVersion == "v1")
             scale(v = dimpleScale) 
             rotate(a = [90,0,0,]) 
                 rotate_extrude($fn=50) 

--- a/Underware/Underware_Hooks.scad
+++ b/Underware/Underware_Hooks.scad
@@ -68,6 +68,8 @@ baseThickness = 3; //.1
 
 
 /*[Slot Customization]*/
+// Version of multiconnect (dimple or snap)
+multiConnectVersion = "v2"; // [v1, v2]
 //Offset the multiconnect on-ramps to be between grid slots rather than on the slot
 onRampHalfOffset = true;
 //Change slot orientation, when enabled slots to come from the top of the back, when disabled slots come from the bottom
@@ -327,12 +329,34 @@ module multiConnectSlotTool(totalHeight) {
             //long slot
             translate(v = [0,0,0]) 
                 rotate(a = [180,0,0]) 
-                linear_extrude(height = totalHeight+1) 
-                    union(){
-                        polygon(points = slotProfile);
-                        mirror([1,0,0])
+                union(){
+                    difference() {
+                        // Main half slot
+                        linear_extrude(height = totalHeight+1) 
                             polygon(points = slotProfile);
-                    }
+                        
+                        // Snap cutout
+                        if (slotQuickRelease == false && multiConnectVersion == "v2")
+                            translate(v= [10.15,0,0])
+                            rotate(a= [-90,0,0])
+                            linear_extrude(height = 5)  // match slot height (5mm)
+                                polygon(points = [[0,0],[-0.4,0],[0,-8]]);  // triangle polygon with multiconnect v2 specs
+                        }
+
+                    mirror([1,0,0])
+                        difference() {
+                            // Main half slot
+                            linear_extrude(height = totalHeight+1) 
+                                polygon(points = slotProfile);
+                            
+                            // Snap cutout
+                            if (slotQuickRelease == false && multiConnectVersion == "v2")
+                                translate(v= [10.15,0,0])
+                                rotate(a= [-90,0,0])
+                                linear_extrude(height = 5)  // match slot height (5mm)
+                                    polygon(points = [[0,0],[-0.4,0],[0,-8]]);  // triangle polygon with multiconnect v2 spec
+                        }
+                }
             //on-ramp
             if(onRampEnabled)
                 for(y = [1:onRampEveryXSlots:totalHeight/distanceBetweenSlots])
@@ -342,11 +366,11 @@ module multiConnectSlotTool(totalHeight) {
                             cylinder(h = 5, r1 = 12, r2 = 10.15);
         }
         //dimple
-        if (slotQuickRelease == false)
+        if (slotQuickRelease == false && multiConnectVersion == "v1")
             scale(v = dimpleScale) 
             rotate(a = [90,0,0,]) 
                 rotate_extrude($fn=50) 
-                    polygon(points = [[0,0],[0,1],[1,0]]);
+                    polygon(points = [[0,0],[0,1.5],[1.5,0]]);
     }
 }
 

--- a/Underware/Underware_Item_Holder.scad
+++ b/Underware/Underware_Item_Holder.scad
@@ -141,6 +141,8 @@ Force_Back_Thickness = 0; //0.1
 
 
 /*[Slot Customization]*/
+// Version of multiconnect (dimple or snap)
+multiConnectVersion = "v2"; // [v1, v2]
 //Offset the multiconnect on-ramps to be between grid slots rather than on the slot
 onRampHalfOffset = true;
 //Change slot orientation, when enabled slots to come from the top of the back, when disabled slots come from the bottom
@@ -368,12 +370,34 @@ module multiconnectBack(backWidth, backHeight, distanceBetweenSlots, slotStopFro
                 //long slot
                 translate(v = [0,0,0]) 
                     rotate(a = [180,0,0]) 
-                    linear_extrude(height = totalDepth+1) 
-                        union(){
-                            polygon(points = slotProfile);
-                            mirror([1,0,0])
+                    union(){
+                        difference() {
+                            // Main half slot
+                            linear_extrude(height = totalDepth+1) 
                                 polygon(points = slotProfile);
-                        }
+                            
+                            // Snap cutout
+                            if (slotQuickRelease == false && multiConnectVersion == "v2")
+                                translate(v= [10.15,0,0])
+                                rotate(a= [-90,0,0])
+                                linear_extrude(height = 5)  // match slot height (5mm)
+                                    polygon(points = [[0,0],[-0.4,0],[0,-8]]);  // triangle polygon with multiconnect v2 specs
+                            }
+
+                        mirror([1,0,0])
+                            difference() {
+                                // Main half slot
+                                linear_extrude(height = totalDepth+1) 
+                                    polygon(points = slotProfile);
+                                
+                                // Snap cutout
+                                if (slotQuickRelease == false && multiConnectVersion == "v2")
+                                    translate(v= [10.15,0,0])
+                                    rotate(a= [-90,0,0])
+                                    linear_extrude(height = 5)  // match slot height (5mm)
+                                        polygon(points = [[0,0],[-0.4,0],[0,-8]]);  // triangle polygon with multiconnect v2 spec
+                            }
+                    }
                 //on-ramp
                 if(onRampEnabled)
                     for(y = [1:onRampEveryXSlots:totalDepth/distanceBetweenSlots])
@@ -383,7 +407,7 @@ module multiconnectBack(backWidth, backHeight, distanceBetweenSlots, slotStopFro
                                 cylinder(h = 5, r1 = 12, r2 = 10.15);
             }
             //dimple
-            if (slotQuickRelease == false)
+            if (slotQuickRelease == false && multiConnectVersion == "v1")
                 scale(v = dimpleScale) 
                 rotate(a = [90,0,0,]) 
                     rotate_extrude($fn=50) 

--- a/Underware/Underware_Item_Holder_Clamshell_Style.scad
+++ b/Underware/Underware_Item_Holder_Clamshell_Style.scad
@@ -140,6 +140,8 @@ Force_Back_Thickness = 0; //0.1
 
 
 /*[Slot Customization]*/
+// Version of multiconnect (dimple or snap)
+multiConnectVersion = "v2"; // [v1, v2]
 //Offset the multiconnect on-ramps to be between grid slots rather than on the slot
 onRampHalfOffset = true;
 //Change slot orientation, when enabled slots to come from the top of the back, when disabled slots come from the bottom
@@ -367,12 +369,34 @@ module multiconnectBack(backWidth, backHeight, distanceBetweenSlots, slotStopFro
                 //long slot
                 translate(v = [0,0,0]) 
                     rotate(a = [180,0,0]) 
-                    linear_extrude(height = totalDepth+1) 
-                        union(){
-                            polygon(points = slotProfile);
-                            mirror([1,0,0])
+                    union(){
+                        difference() {
+                            // Main half slot
+                            linear_extrude(height = totalDepth+1) 
                                 polygon(points = slotProfile);
-                        }
+                            
+                            // Snap cutout
+                            if (slotQuickRelease == false && multiConnectVersion == "v2")
+                                translate(v= [10.15,0,0])
+                                rotate(a= [-90,0,0])
+                                linear_extrude(height = 5)  // match slot height (5mm)
+                                    polygon(points = [[0,0],[-0.4,0],[0,-8]]);  // triangle polygon with multiconnect v2 specs
+                            }
+
+                        mirror([1,0,0])
+                            difference() {
+                                // Main half slot
+                                linear_extrude(height = totalDepth+1) 
+                                    polygon(points = slotProfile);
+                                
+                                // Snap cutout
+                                if (slotQuickRelease == false && multiConnectVersion == "v2")
+                                    translate(v= [10.15,0,0])
+                                    rotate(a= [-90,0,0])
+                                    linear_extrude(height = 5)  // match slot height (5mm)
+                                        polygon(points = [[0,0],[-0.4,0],[0,-8]]);  // triangle polygon with multiconnect v2 spec
+                            }
+                    }
                 //on-ramp
                 if(onRampEnabled)
                     for(y = [1:onRampEveryXSlots:totalDepth/distanceBetweenSlots])
@@ -382,7 +406,7 @@ module multiconnectBack(backWidth, backHeight, distanceBetweenSlots, slotStopFro
                                 cylinder(h = 5, r1 = 12, r2 = 10.15);
             }
             //dimple
-            if (slotQuickRelease == false)
+            if (slotQuickRelease == false && multiConnectVersion == "v1")
                 scale(v = dimpleScale) 
                 rotate(a = [90,0,0,]) 
                     rotate_extrude($fn=50) 

--- a/VerticalMountingSeries/InProgress/MultiConnectRoundRowBOSL.scad
+++ b/VerticalMountingSeries/InProgress/MultiConnectRoundRowBOSL.scad
@@ -47,6 +47,8 @@ shelfStepdown = 5; //.1
 
 
 /*[Slot Customization]*/
+// Version of multiconnect (dimple or snap)
+multiConnectVersion = "v2"; // [v1, v2]
 //Distance between Multiconnect slots on the back (25mm is standard for MultiBoard)
 distanceBetweenSlots = 25;
 //QuickRelease removes the small indent in the top of the slots that lock the part into place
@@ -146,21 +148,43 @@ module multiconnectBack(backWidth, backHeight, distanceBetweenSlots)
                 //long slot
                 translate(v = [0,0,0]) 
                     rotate(a = [180,0,0]) 
-                    linear_extrude(height = totalHeight+1) 
-                        union(){
-                            polygon(points = slotProfile);
-                            mirror([1,0,0])
+                    union(){
+                        difference() {
+                            // Main half slot
+                            linear_extrude(height = totalHeight+1) 
                                 polygon(points = slotProfile);
-                        }
+                            
+                            // Snap cutout
+                            if (slotQuickRelease == false && multiConnectVersion == "v2")
+                                translate(v= [10.15,0,0])
+                                rotate(a= [-90,0,0])
+                                linear_extrude(height = 5)  // match slot height (5mm)
+                                    polygon(points = [[0,0],[-0.4,0],[0,-8]]);  // triangle polygon with multiconnect v2 specs
+                            }
+
+                        mirror([1,0,0])
+                            difference() {
+                                // Main half slot
+                                linear_extrude(height = totalHeight+1) 
+                                    polygon(points = slotProfile);
+                                
+                                // Snap cutout
+                                if (slotQuickRelease == false && multiConnectVersion == "v2")
+                                    translate(v= [10.15,0,0])
+                                    rotate(a= [-90,0,0])
+                                    linear_extrude(height = 5)  // match slot height (5mm)
+                                        polygon(points = [[0,0],[-0.4,0],[0,-8]]);  // triangle polygon with multiconnect v2 spec
+                            }
+                    }
                 //on-ramp
                 if(onRampEnabled)
                     for(y = [1:onRampEveryXSlots:totalHeight/distanceBetweenSlots])
                         translate(v = [0,-5,-y*distanceBetweenSlots]) 
                             rotate(a = [-90,0,0]) 
-                                color(c = "orange") cylinder(h = 5, r1 = 12, r2 = 10.15);
+                                cylinder(h = 5, r1 = 12, r2 = 10.15);
             }
             //dimple
-            if (slotQuickRelease == false)
+            if (slotQuickRelease == false && multiConnectVersion == "v1")
                 scale(v = dimpleScale) 
                 rotate(a = [90,0,0,]) 
                     rotate_extrude($fn=50) 

--- a/VerticalMountingSeries/MultiConnectRoundRow.scad
+++ b/VerticalMountingSeries/MultiConnectRoundRow.scad
@@ -58,6 +58,8 @@ forceFlatFront = false;
 //Shelf stepdown is the heigh (in mm) that rows/shelves will vertically step down. If zero, all rows will be on the same plane. 
 shelfStepdown = 5; //.1
 /*[Slot Customization]*/
+// Version of multiconnect (dimple or snap)
+multiConnectVersion = "v2"; // [v1, v2]
 onRampHalfOffset = true;
 //Distance between Multiconnect slots on the back (25mm is standard for MultiBoard)
 customDistanceBetweenSlots = 25;
@@ -319,12 +321,34 @@ module multiConnectSlotTool(totalHeight) {
             //long slot
             translate(v = [0,0,0]) 
                 rotate(a = [180,0,0]) 
-                linear_extrude(height = totalHeight+1) 
-                    union(){
-                        polygon(points = slotProfile);
-                        mirror([1,0,0])
+                union(){
+                    difference() {
+                        // Main half slot
+                        linear_extrude(height = totalHeight+1) 
                             polygon(points = slotProfile);
-                    }
+                        
+                        // Snap cutout
+                        if (slotQuickRelease == false && multiConnectVersion == "v2")
+                            translate(v= [10.15,0,0])
+                            rotate(a= [-90,0,0])
+                            linear_extrude(height = 5)  // match slot height (5mm)
+                                polygon(points = [[0,0],[-0.4,0],[0,-8]]);  // triangle polygon with multiconnect v2 specs
+                        }
+
+                    mirror([1,0,0])
+                        difference() {
+                            // Main half slot
+                            linear_extrude(height = totalHeight+1) 
+                                polygon(points = slotProfile);
+                            
+                            // Snap cutout
+                            if (slotQuickRelease == false && multiConnectVersion == "v2")
+                                translate(v= [10.15,0,0])
+                                rotate(a= [-90,0,0])
+                                linear_extrude(height = 5)  // match slot height (5mm)
+                                    polygon(points = [[0,0],[-0.4,0],[0,-8]]);  // triangle polygon with multiconnect v2 spec
+                        }
+                }
             //on-ramp
             if(onRampEnabled)
                 for(y = [1:onRampEveryXSlots:totalHeight/distanceBetweenSlots])
@@ -334,7 +358,7 @@ module multiConnectSlotTool(totalHeight) {
                             cylinder(h = 5, r1 = 12, r2 = 10.15);
         }
         //dimple
-        if (slotQuickRelease == false)
+        if (slotQuickRelease == false && multiConnectVersion == "v1")
             scale(v = dimpleScale) 
             rotate(a = [90,0,0,]) 
                 rotate_extrude($fn=50) 

--- a/VerticalMountingSeries/MultiConnectRoundSingleHolder.scad
+++ b/VerticalMountingSeries/MultiConnectRoundSingleHolder.scad
@@ -34,6 +34,8 @@ holeCutoutDiameter = 10;
 slotCutout = false;
 
 /*[Slot Customization]*/
+// Version of multiconnect (dimple or snap)
+multiConnectVersion = "v2"; // [v1, v2]
 //Distance between Multiconnect slots on the back (25mm is standard for MultiBoard)
 distanceBetweenSlots = 25;
 //QuickRelease removes the small indent in the top of the slots that lock the part into place
@@ -136,12 +138,34 @@ module multiconnectBack(backWidth, backHeight, distanceBetweenSlots)
                 //long slot
                 translate(v = [0,0,0]) 
                     rotate(a = [180,0,0]) 
-                    linear_extrude(height = totalHeight+1) 
-                        union(){
-                            polygon(points = slotProfile);
-                            mirror([1,0,0])
+                    union(){
+                        difference() {
+                            // Main half slot
+                            linear_extrude(height = totalHeight+1) 
                                 polygon(points = slotProfile);
-                        }
+                            
+                            // Snap cutout
+                            if (slotQuickRelease == false && multiConnectVersion == "v2")
+                                translate(v= [10.15,0,0])
+                                rotate(a= [-90,0,0])
+                                linear_extrude(height = 5)  // match slot height (5mm)
+                                    polygon(points = [[0,0],[-0.4,0],[0,-8]]);  // triangle polygon with multiconnect v2 specs
+                            }
+
+                        mirror([1,0,0])
+                            difference() {
+                                // Main half slot
+                                linear_extrude(height = totalHeight+1) 
+                                    polygon(points = slotProfile);
+                                
+                                // Snap cutout
+                                if (slotQuickRelease == false && multiConnectVersion == "v2")
+                                    translate(v= [10.15,0,0])
+                                    rotate(a= [-90,0,0])
+                                    linear_extrude(height = 5)  // match slot height (5mm)
+                                        polygon(points = [[0,0],[-0.4,0],[0,-8]]);  // triangle polygon with multiconnect v2 spec
+                            }
+                    }
                 //on-ramp
                 if(onRampEnabled)
                     for(y = [1:onRampEveryXSlots:totalHeight/distanceBetweenSlots])
@@ -150,7 +174,7 @@ module multiconnectBack(backWidth, backHeight, distanceBetweenSlots)
                                 cylinder(h = 5, r1 = 12, r2 = 10.15);
             }
             //dimple
-            if (slotQuickRelease == false)
+            if (slotQuickRelease == false && multiConnectVersion == "v1")
                 scale(v = dimpleScale) 
                 rotate(a = [90,0,0,]) 
                     rotate_extrude($fn=50) 

--- a/VerticalMountingSeries/MulticonnectGridfinity.SCAD
+++ b/VerticalMountingSeries/MulticonnectGridfinity.SCAD
@@ -36,6 +36,8 @@ removeBase = true;
 bracketDepthPercentage = 50; //[0:1:100]
 
 /*[Slot Customization]*/
+// Version of multiconnect (dimple or snap)
+multiConnectVersion = "v2"; // [v1, v2]
 onRampHalfOffset = true;
 //Distance between Multiconnect slots on the back (25mm is standard for MultiBoard)
 customDistanceBetweenSlots = 25;
@@ -284,12 +286,34 @@ module multiConnectSlotTool(totalHeight) {
             //long slot
             translate(v = [0,0,0]) 
                 rotate(a = [180,0,0]) 
-                linear_extrude(height = totalHeight+1) 
-                    union(){
-                        polygon(points = slotProfile);
-                        mirror([1,0,0])
+                union(){
+                    difference() {
+                        // Main half slot
+                        linear_extrude(height = totalHeight+1) 
                             polygon(points = slotProfile);
-                    }
+                        
+                        // Snap cutout
+                        if (slotQuickRelease == false && multiConnectVersion == "v2")
+                            translate(v= [10.15,0,0])
+                            rotate(a= [-90,0,0])
+                            linear_extrude(height = 5)  // match slot height (5mm)
+                                polygon(points = [[0,0],[-0.4,0],[0,-8]]);  // triangle polygon with multiconnect v2 specs
+                        }
+
+                    mirror([1,0,0])
+                        difference() {
+                            // Main half slot
+                            linear_extrude(height = totalHeight+1) 
+                                polygon(points = slotProfile);
+                            
+                            // Snap cutout
+                            if (slotQuickRelease == false && multiConnectVersion == "v2")
+                                translate(v= [10.15,0,0])
+                                rotate(a= [-90,0,0])
+                                linear_extrude(height = 5)  // match slot height (5mm)
+                                    polygon(points = [[0,0],[-0.4,0],[0,-8]]);  // triangle polygon with multiconnect v2 spec
+                        }
+                }
             //on-ramp
             if(onRampEnabled)
                 for(y = [1:onRampEveryXSlots:totalHeight/distanceBetweenSlots])
@@ -299,7 +323,7 @@ module multiConnectSlotTool(totalHeight) {
                             cylinder(h = 5, r1 = 12, r2 = 10.15);
         }
         //dimple
-        if (slotQuickRelease == false)
+        if (slotQuickRelease == false && multiConnectVersion == "v1")
             scale(v = dimpleScale) 
             rotate(a = [90,0,0,]) 
                 rotate_extrude($fn=50) 

--- a/VerticalMountingSeries/MulticonnectHook.scad
+++ b/VerticalMountingSeries/MulticonnectHook.scad
@@ -26,6 +26,8 @@ backRadius = 2;
 
 
 /*[Slot Customization]*/
+// Version of multiconnect (dimple or snap)
+multiConnectVersion = "v2"; // [v1, v2]
 //Distance between Multiconnect slots on the back (25mm is standard for MultiBoard)
 distanceBetweenSlots = 25;
 //QuickRelease removes the small indent in the top of the slots that lock the part into place
@@ -91,12 +93,34 @@ module multiconnectBack(backWidth, backHeight, distanceBetweenSlots)
                 //long slot
                 translate(v = [0,0,0]) 
                     rotate(a = [180,0,0]) 
-                    linear_extrude(height = totalHeight+1) 
-                        union(){
-                            polygon(points = slotProfile);
-                            mirror([1,0,0])
+                    union(){
+                        difference() {
+                            // Main half slot
+                            linear_extrude(height = totalHeight+1) 
                                 polygon(points = slotProfile);
-                        }
+                            
+                            // Snap cutout
+                            if (slotQuickRelease == false && multiConnectVersion == "v2")
+                                translate(v= [10.15,0,0])
+                                rotate(a= [-90,0,0])
+                                linear_extrude(height = 5)  // match slot height (5mm)
+                                    polygon(points = [[0,0],[-0.4,0],[0,-8]]);  // triangle polygon with multiconnect v2 specs
+                            }
+
+                        mirror([1,0,0])
+                            difference() {
+                                // Main half slot
+                                linear_extrude(height = totalHeight+1) 
+                                    polygon(points = slotProfile);
+                                
+                                // Snap cutout
+                                if (slotQuickRelease == false && multiConnectVersion == "v2")
+                                    translate(v= [10.15,0,0])
+                                    rotate(a= [-90,0,0])
+                                    linear_extrude(height = 5)  // match slot height (5mm)
+                                        polygon(points = [[0,0],[-0.4,0],[0,-8]]);  // triangle polygon with multiconnect v2 spec
+                            }
+                    }
                 //on-ramp
                 if(onRampEnabled)
                     for(y = [1:onRampEveryXSlots:totalHeight/distanceBetweenSlots])
@@ -105,7 +129,7 @@ module multiconnectBack(backWidth, backHeight, distanceBetweenSlots)
                                 cylinder(h = 5, r1 = 12, r2 = 10.15);
             }
             //dimple
-            if (slotQuickRelease == false)
+            if (slotQuickRelease == false && multiConnectVersion == "v1")
                 scale(v = dimpleScale) 
                 rotate(a = [90,0,0,]) 
                     rotate_extrude($fn=50) 

--- a/VerticalMountingSeries/MulticonnectShelf.scad
+++ b/VerticalMountingSeries/MulticonnectShelf.scad
@@ -23,6 +23,8 @@ wallThickness = 3; //.1
 baseThickness = 3; //.1
 
 /*[Slot Customization]*/
+// Version of multiconnect (dimple or snap)
+multiConnectVersion = "v2"; // [v1, v2]
 //Distance between Multiconnect slots on the back (25mm is standard for MultiBoard)
 distanceBetweenSlots = 25;
 //QuickRelease removes the small indent in the top of the slots that lock the part into place
@@ -130,12 +132,34 @@ module multiconnectBack(backWidth, backHeight, distanceBetweenSlots)
                 //long slot
                 translate(v = [0,0,0]) 
                     rotate(a = [180,0,0]) 
-                    linear_extrude(height = totalHeight+1) 
-                        union(){
-                            polygon(points = slotProfile);
-                            mirror([1,0,0])
+                    union(){
+                        difference() {
+                            // Main half slot
+                            linear_extrude(height = totalHeight+1) 
                                 polygon(points = slotProfile);
-                        }
+                            
+                            // Snap cutout
+                            if (slotQuickRelease == false && multiConnectVersion == "v2")
+                                translate(v= [10.15,0,0])
+                                rotate(a= [-90,0,0])
+                                linear_extrude(height = 5)  // match slot height (5mm)
+                                    polygon(points = [[0,0],[-0.4,0],[0,-8]]);  // triangle polygon with multiconnect v2 specs
+                            }
+
+                        mirror([1,0,0])
+                            difference() {
+                                // Main half slot
+                                linear_extrude(height = totalHeight+1) 
+                                    polygon(points = slotProfile);
+                                
+                                // Snap cutout
+                                if (slotQuickRelease == false && multiConnectVersion == "v2")
+                                    translate(v= [10.15,0,0])
+                                    rotate(a= [-90,0,0])
+                                    linear_extrude(height = 5)  // match slot height (5mm)
+                                        polygon(points = [[0,0],[-0.4,0],[0,-8]]);  // triangle polygon with multiconnect v2 spec
+                            }
+                    }
                 //on-ramp
                 if(onRampEnabled)
                     for(y = [1:onRampEveryXSlots:totalHeight/distanceBetweenSlots])
@@ -144,7 +168,7 @@ module multiconnectBack(backWidth, backHeight, distanceBetweenSlots)
                                 cylinder(h = 5, r1 = 12, r2 = 10.15);
             }
             //dimple
-            if (slotQuickRelease == false)
+            if (slotQuickRelease == false && multiConnectVersion == "v1")
                 scale(v = dimpleScale) 
                 rotate(a = [90,0,0,]) 
                     rotate_extrude($fn=50) 

--- a/VerticalMountingSeries/VerticalItemHolder.scad
+++ b/VerticalMountingSeries/VerticalItemHolder.scad
@@ -119,6 +119,8 @@ baseThickness = 3; //.1
 
 
 /*[Slot Customization]*/
+// Version of multiconnect (dimple or snap)
+multiConnectVersion = "v2"; // [v1, v2]
 onRampHalfOffset = true;
 //Distance between Multiconnect slots on the back (25mm is standard for MultiBoard)
 customDistanceBetweenSlots = 25;
@@ -380,12 +382,34 @@ module multiConnectSlotTool(totalHeight) {
             //long slot
             translate(v = [0,0,0]) 
                 rotate(a = [180,0,0]) 
-                linear_extrude(height = totalHeight+1) 
-                    union(){
-                        polygon(points = slotProfile);
-                        mirror([1,0,0])
+                union(){
+                    difference() {
+                        // Main half slot
+                        linear_extrude(height = totalHeight+1) 
                             polygon(points = slotProfile);
-                    }
+                        
+                        // Snap cutout
+                        if (slotQuickRelease == false && multiConnectVersion == "v2")
+                            translate(v= [10.15,0,0])
+                            rotate(a= [-90,0,0])
+                            linear_extrude(height = 5)  // match slot height (5mm)
+                                polygon(points = [[0,0],[-0.4,0],[0,-8]]);  // triangle polygon with multiconnect v2 specs
+                        }
+
+                    mirror([1,0,0])
+                        difference() {
+                            // Main half slot
+                            linear_extrude(height = totalHeight+1) 
+                                polygon(points = slotProfile);
+                            
+                            // Snap cutout
+                            if (slotQuickRelease == false && multiConnectVersion == "v2")
+                                translate(v= [10.15,0,0])
+                                rotate(a= [-90,0,0])
+                                linear_extrude(height = 5)  // match slot height (5mm)
+                                    polygon(points = [[0,0],[-0.4,0],[0,-8]]);  // triangle polygon with multiconnect v2 spec
+                        }
+                }
             //on-ramp
             if(onRampEnabled)
                 for(y = [1:onRampEveryXSlots:totalHeight/distanceBetweenSlots])
@@ -395,14 +419,13 @@ module multiConnectSlotTool(totalHeight) {
                             cylinder(h = 5, r1 = 12, r2 = 10.15);
         }
         //dimple
-        if (slotQuickRelease == false)
+        if (slotQuickRelease == false && multiConnectVersion == "v1")
             scale(v = dimpleScale) 
             rotate(a = [90,0,0,]) 
                 rotate_extrude($fn=50) 
                     polygon(points = [[0,0],[0,1.5],[1.5,0]]);
     }
 }
-
 module multiPointSlotTool(totalHeight) {
     slotBaseRadius = 17.0 / 2.0;  // wider width of the inner part of the channel
     slotSkinRadius = 13.75 / 2.0;  // narrower part of the channel near the skin of the model


### PR DESCRIPTION
Updates all Multiconnect slot generators with an option to select between v1 or v2 of Multiconnect .

A new parameter `multiConnectVersion` is added under "Slot Customization" with the default to Multiconnect v2.

- Selecting v1 will still use the dimple instead of the snap mechanism.
- Selecting v2 will use the new snap mechanism instead of the dimple.

If the parameter `slotQuickRelease` is set to `true`, neither the dimple or the snap will be present in the slot.

Took the opportunity to also homogenize the slot module format across all the files 