### PR TITLE
Rework rounded item generator

### DIFF
--- a/VerticalMountingSeries/MultiConnectRoundSingleHolder.scad
+++ b/VerticalMountingSeries/MultiConnectRoundSingleHolder.scad
@@ -11,187 +11,270 @@ Change Log:
     - Initial Release
 - 2025-03-11
     - Hole Cutout and Slot Cutout added (thanks @user_3620134323)
--2025-07-15
+- 2025-07-15
     - New Multiconnect v2 option added with improved holding (thanks @dontic on GitHub!)
+- 2025-07-19 @timtucker
+    - Curved support structure (should be stronger, print faster, and use less filament)
+    - Allow the hole / slot to be repositioned
+    - Prevent the hole / slot from extending into the back wall
+    - Allow tuning of the resolution of circles and curves
+    - Simplify / reorganize parameters
 */
 
 /*[Parameters]*/
-//diameter (in mm) of the item you wish to insert (this becomes the internal diameter)
-itemDiameter = 50; //0.1
-//thickness (in mm) of the wall surrounding the item
-rimThickness = 1;
-//Thickness (in mm) of the base underneath the item you are holding
-baseThickness = 3;
-//Additional thickness of the area between the item holding and the backer.
-shelfSupportHeight = 3;
-//Additional height (in mm) of the rim protruding upward to hold the item
-rimHeight = 10;
-//Additional Backer Height (in mm) in case you prefer additional support for something heavy
-additionalBackerHeight = 0;
-//Offset the holding position from the back wall
+// Diameter (in mm) of the item you wish to insert (this becomes the internal diameter)
+itemDiameter = 50; // 0.1
+// Distance (in mm) from the back wall to the back rim
 offSet = 0;
-//Use cutout for holding items that are wider at the top
-useCutout = false;
 
-/*[Hole Cutout Customizations]*/
-holeCutout = false;
-//diameter/width of cord cutout
-holeCutoutDiameter = 10;
-//cut out a slot on the bottom and through the front
-slotCutout = false;
+/*[Rim]*/
+// Height (in mm) of the rim protruding upward to hold the item
+rimHeight = 10;
+// Thickness (in mm) of the wall surrounding the item
+rimThickness = 1;
 
-/*[Slot Customization]*/
+/*[Cutout]*/
+// Diameter of a hole (in mm) for items to pass through (leave 0 for no cutout)
+cutoutDiameter = 0;
+// Offset from the center (in mm) for the hole to start (postive values extend towards the front wall, negative values extend towards the back wall)
+cutoutStart = 0;
+// Offset from the center (in mm) for the hole to end (postive values extend towards the front wall, negative values extend towards the back wall)
+cutoutEnd = 0;
+
+/*[Support]*/
+// Thickness (in mm) of the base underneath the item you are holding (leave 0 for an open hole to hang items)
+baseThickness = 3;
+// If the rim is shorter than the total height, slope towards the back wall
+slopeTowardsBackWall = true;
+
+/*[Multiconnect]*/
 // Version of multiconnect (dimple or snap)
 multiConnectVersion = "v2"; // [v1, v2]
-//Distance between Multiconnect slots on the back (25mm is standard for MultiBoard)
+// Distance between Multiconnect slots on the back (25mm is standard for MultiBoard, 28mm for openGrid)
 distanceBetweenSlots = 25;
-//QuickRelease removes the small indent in the top of the slots that lock the part into place
+// Number of vertical slots for the attachment (recommended to have at least 1/4 the item diameter)
+slotsHigh = 1; // [1:0.5:20]
+// Number of horizontal slots for the attachment
+slotsWide = 2; // [1:1:20]
+// QuickRelease removes the small indent in the top of the slots that lock the part into place
 slotQuickRelease = false;
-//Dimple scale tweaks the size of the dimple in the slot for printers that need a larger dimple to print correctly
-dimpleScale = 1; //[0.5:.05:1.5]
-//Scale the size of slots in the back (1.015 scale is default for a tight fit. Increase if your finding poor fit. )
-slotTolerance = 1.00; //[0.925:0.005:1.075]
-//Move the slot in (positive) or out (negative)
-slotDepthMicroadjustment = 0; //[-.5:0.05:.5]
-//enable a slot on-ramp for easy mounting of tall items
+// Dimple scale tweaks the size of the dimple in the slot for printers that need a larger dimple to print correctly
+dimpleScale = 1; // [0.5:0.05:1.5]
+// Scale the size of slots in the back (1.015 scale is default for a tight fit. Increase if your finding poor fit. )
+slotTolerance = 1.00; // [0.925:0.005:1.075]
+// Move the slot in (positive) or out (negative)
+slotDepthMicroadjustment = 0; // [-.5:0.05:.5]
+// Enable a slot on-ramp for easy mounting of tall items
 onRampEnabled = true;
-//frequency of slots for on-ramp. 1 = every slot; 2 = every 2 slots; etc.
+// Frequency of slots for on-ramp. 1 = every slot; 2 = every 2 slots; etc.
 onRampEveryXSlots = 1;
 
+/*[Performance]*/
+// Resolution for circles and curves (higher values are smoother but slower to render)
+circleResolution = 500; // [50:50:1000]
 
 /*[Hidden]*/
-totalWidth = itemDiameter + rimThickness*2;
-totalHeight = max(baseThickness+shelfSupportHeight+0.25*itemDiameter,25);
 
-//start build
-translate(v = [-max(totalWidth,distanceBetweenSlots)/2,0,0]) 
-    multiconnectBack(backWidth = totalWidth, backHeight = totalHeight+additionalBackerHeight, distanceBetweenSlots = distanceBetweenSlots);
-    //item holder
-translate(v = [-totalWidth/2,0,0]) 
-union() {
-    difference() {
-        //itemwalls
-        union() {
-            hull(){
-                translate(v = [totalWidth/2,itemDiameter/2+offSet,0])
-                //outer circle
-                linear_extrude(height = shelfSupportHeight+baseThickness)
-                    circle(r = itemDiameter/2+rimThickness, $fn=50);
-                //wide back for hull operation
-                linear_extrude(height = shelfSupportHeight+baseThickness)
-                    square(size = [totalWidth,1]);
+// Shortcuts for reference measurements and positions
+totalWidth = itemDiameter + rimThickness * 2;
+totalHeight = slotsHigh * distanceBetweenSlots;
+itemCenterX = totalWidth / 2;
+itemCenterY = totalWidth / 2 + offSet;
+heightAboveRim = totalHeight - rimHeight;
+
+maxZHeight = max(totalHeight, rimHeight + baseThickness);
+
+beyondX = itemCenterX * 10;
+beyondY = itemCenterY * 10;
+beyondZ = maxZHeight * 10;
+
+// Curve support angling up towards the back wall
+supportHeight = slopeTowardsBackWall ? totalHeight : rimHeight + baseThickness;
+supportCurveY = itemCenterY * 2;
+supportCurveZ = heightAboveRim * 2;
+
+// Stop the cutout from extending into the back wall
+adjustedCutoutDiameter = min(cutoutDiameter, itemDiameter);
+adjustedCutoutStart = max((adjustedCutoutDiameter/2) - itemCenterY, cutoutStart);
+adjustedCutoutEnd = max((adjustedCutoutDiameter/2) - itemCenterY, cutoutEnd);
+
+offsetWidth = min(totalWidth, distanceBetweenSlots * slotsWide);
+
+//item holder
+difference() {
+    // Item holder and support structure
+    union() {
+        // Outer cylinder for the item holder
+        createElongatedRoundObject(height = rimHeight + baseThickness, diameter = totalWidth, yCenterStart = itemCenterY, yCenterEnd = itemCenterY, circleResolution = circleResolution);
+
+        // Support structure
+        difference() {
+            // Fill the space between the item holder and the back wall along the base
+            hull() {
+                createElongatedRoundObject(height = supportHeight, diameter = totalWidth, yCenterStart = itemCenterY, yCenterEnd = itemCenterY, circleResolution = circleResolution);
+
+                // Create the shell to hold the multiconnect slots
+                createMulticonnectBackShell(distanceBetweenSlots = distanceBetweenSlots, slotsWide = slotsWide, slotsHigh = slotsHigh);
             }
-            //thin holding wall
-            translate(v = [totalWidth/2,itemDiameter/2+offSet,shelfSupportHeight+baseThickness])
-                linear_extrude(height = rimHeight)
-                    circle(r = itemDiameter/2+rimThickness, $fn=50);
-        }
-        union(){
-        //itemDiameter (i.e., delete tool)
-            translate(v = [totalWidth/2,(itemDiameter/2)+offSet,baseThickness+.5 - (useCutout?+(baseThickness*2)+1:0)]) 
-                linear_extrude(height = shelfSupportHeight+rimHeight+1+(useCutout?+(baseThickness*2):0)) 
-                    circle(r = itemDiameter/2, $fn=50);
 
-            //tool hole
-            if (holeCutout == true) {
-                translate(v = [totalWidth/2,(itemDiameter/2)+offSet]) union() {
-                    linear_extrude(height = baseThickness*10) circle(r = holeCutoutDiameter/2, $fn=50);
-
-                    if (slotCutout == true) {
-                        translate(v = [-holeCutoutDiameter/2,0,0]) 
-                            cube([holeCutoutDiameter, totalWidth/2, totalHeight]);
+            // Slope from rim to back wall
+            if (slopeTowardsBackWall == true && totalHeight > rimHeight + baseThickness) {
+                union() {
+                    // For the curve, subtract a cylinder that extends from the rim up to the back wall
+                    translate(v = [-0.5 * beyondX, supportCurveY / 2, baseThickness + rimHeight + (supportCurveZ / 2)]) {
+                        scale(v = [1, supportCurveY, supportCurveZ]) {
+                            rotate([0, 90, 0]) {
+                                cylinder(h = beyondY, d = 1, $fn = circleResolution);
+                            }
+                        }
+                    }
+                    // Remove the front half of the cylinder
+                    translate(v = [-0.5* beyondX, itemCenterY, rimHeight + baseThickness]) {
+                        cube([beyondX, beyondY, beyondZ]);
                     }
                 }
             }
         }
     }
-    //brackets
-    bracketSize = min(totalHeight-baseThickness-shelfSupportHeight, itemDiameter/2);
-    translate(v = [rimThickness,0,bracketSize+baseThickness+shelfSupportHeight]) 
-        shelfBracket(bracketHeight = bracketSize, bracketDepth = bracketSize, rimThickness = rimThickness);
-    translate(v = [rimThickness*2+itemDiameter,0,bracketSize+baseThickness+shelfSupportHeight]) 
-        shelfBracket(bracketHeight = bracketSize, bracketDepth = bracketSize, rimThickness = rimThickness);
+    union() {
+        // Cut out a cylinder for the item to fit into
+        translate(v = [0, 0, (baseThickness > 0) ? baseThickness : -0.5 * beyondZ]) {
+            createElongatedRoundObject(height = beyondZ, diameter = itemDiameter, yCenterStart = itemCenterY, yCenterEnd = itemCenterY, circleResolution = circleResolution);
+        }
+
+        // Cut out a hole / slot
+        createCutout(holeDiameter = adjustedCutoutDiameter, yCenterStart = itemCenterY + adjustedCutoutStart, yCenterEnd = itemCenterY + adjustedCutoutEnd, circleResolution = circleResolution);
+
+        // Remove the slots for multiconnect
+        translate(v = [-(slotsWide * distanceBetweenSlots)/2,0,0]) {
+            createMulticonnectSlots(backWidth = slotsWide * distanceBetweenSlots, backHeight = slotsHigh * distanceBetweenSlots, distanceBetweenSlots = distanceBetweenSlots, circleResolution = circleResolution);
+        }
+    }
+}
+
+module createCutout(holeDiameter=0, yCenterStart=0, yCenterEnd=0, circleResolution=100) {
+    // Use extreme values to ensure that the cutout extends beyond the bounds of the object
+    translate(v = [0, 0, -0.5 * beyondZ]) {
+        createElongatedRoundObject(height = beyondZ, diameter = holeDiameter, yCenterStart = yCenterStart, yCenterEnd = yCenterEnd, circleResolution = circleResolution);
+    }
+}
+
+module createElongatedRoundObject(height, diameter=0, xCenterStart=0, xCenterEnd=0, yCenterStart=0, yCenterEnd=0, circleResolution=100) {
+    // There's no object to create if the diameter is 0 or less
+    if (diameter > 0) {
+        // Create an elongated round object (like a cylinder) that extends from start to end position
+        hull() {
+            // Starting position for the object
+            translate(v = [xCenterStart, yCenterStart, 0]) {
+                cylinder(h = height, d = diameter, $fn = circleResolution);
+            }
+            
+            // Ending position for the object
+            translate(v = [xCenterEnd, yCenterEnd, 0]) {
+                cylinder(h = height, d = diameter, $fn = circleResolution);
+            }
+        }
+    }
 }
 
 //BEGIN MODULES
 //Slotted back Module
-module multiconnectBack(backWidth, backHeight, distanceBetweenSlots)
+module createMulticonnectSlots(backWidth, backHeight, distanceBetweenSlots, circleResolution=100)
 {
     //slot count calculates how many slots can fit on the back. Based on internal width for buffer. 
     //slot width needs to be at least the distance between slot for at least 1 slot to generate
-    let (backWidth = max(backWidth,distanceBetweenSlots), backHeight = max(backHeight, 25),slotCount = floor(backWidth/distanceBetweenSlots), backThickness = 6.5){
+    let (backWidth = max(backWidth, distanceBetweenSlots), backHeight = max(backHeight, distanceBetweenSlots), slotCount = floor(backWidth / distanceBetweenSlots), backThickness = 6.5){
+        //Loop through slots and center on the item
+        //Note: I kept doing math until it looked right. It's possible this can be simplified.
+        for (slotNum = [0:1:slotCount-1]) {
+            translate(v = [distanceBetweenSlots/2+(backWidth/distanceBetweenSlots-slotCount)*distanceBetweenSlots/2+slotNum*distanceBetweenSlots,-2.35+slotDepthMicroadjustment,backHeight-13]) {
+                slotTool(backHeight);
+            }
+        }
+    }
+
+    // Create Slot Tool
+    module slotTool(totalHeight) {
+        scale(v = slotTolerance)
+        // Slot minus optional dimple with optional on-ramp
+        let (slotProfile = [[0,0],[10.15,0],[10.15,1.2121],[7.65,3.712],[7.65,5],[0,5]])
         difference() {
-            translate(v = [0,-backThickness,0]) cube(size = [backWidth,backThickness,backHeight]);
-            //Loop through slots and center on the item
-            //Note: I kept doing math until it looked right. It's possible this can be simplified.
-            for (slotNum = [0:1:slotCount-1]) {
-                translate(v = [distanceBetweenSlots/2+(backWidth/distanceBetweenSlots-slotCount)*distanceBetweenSlots/2+slotNum*distanceBetweenSlots,-2.35+slotDepthMicroadjustment,backHeight-13]) {
-                    slotTool(backHeight);
+            union() {
+                // Round top
+                rotate(a = [90,0,0,]) {
+                    rotate_extrude($fn = circleResolution) {
+                        polygon(points = slotProfile);
+                    }
+                }
+
+                // Long slot
+                translate(v = [0,0,0]) 
+                    rotate(a = [180,0,0])
+                    union() {
+                        difference() {
+                            // Main half slot
+                            linear_extrude(height = totalHeight+1) {
+                                polygon(points = slotProfile);
+                            }
+                            
+                            // Snap cutout
+                            if (slotQuickRelease == false && multiConnectVersion == "v2") {
+                                translate(v= [10.15,0,0]) {
+                                    rotate(a= [-90,0,0]) {
+                                        linear_extrude(height = 5) {  // match slot height (5mm)
+                                            polygon(points = [[0,0],[-0.4,0],[0,-8]]);  // triangle polygon with multiconnect v2 specs
+                                        }
+                                    }
+                                }
+                            }
+                        }
+
+                        mirror([1,0,0]) {
+                            difference() {
+                                // Main half slot
+                                linear_extrude(height = totalHeight+1) {
+                                    polygon(points = slotProfile);
+                                }
+                                
+                                // Snap cutout
+                                if (slotQuickRelease == false && multiConnectVersion == "v2") {
+                                    translate(v= [10.15,0,0]) {
+                                        rotate(a= [-90,0,0]) {
+                                            linear_extrude(height = 5) {  // match slot height (5mm)
+                                                polygon(points = [[0,0],[-0.4,0],[0,-8]]);  // triangle polygon with multiconnect v2 spec
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                // On-ramp
+                if(onRampEnabled)
+                    for(y = [1:onRampEveryXSlots:totalHeight/distanceBetweenSlots]) {
+                        translate(v = [0,-5,-y*distanceBetweenSlots]) {
+                            rotate(a = [-90,0,0]) {
+                                cylinder(h = 5, r1 = 12, r2 = 10.15);
+                            }
+                        }
+                    }
+            }
+            // Dimple
+            if (slotQuickRelease == false && multiConnectVersion == "v1") {
+                scale(v = dimpleScale) {
+                    rotate(a = [90,0,0,]) {
+                        rotate_extrude($fn = circleResolution) {
+                            polygon(points = [[0,0],[0,1.5],[1.5,0]]);
+                        }
+                    }
                 }
             }
         }
     }
-    //Create Slot Tool
-    module slotTool(totalHeight) {
-        scale(v = slotTolerance)
-        //slot minus optional dimple with optional on-ramp
-        let (slotProfile = [[0,0],[10.15,0],[10.15,1.2121],[7.65,3.712],[7.65,5],[0,5]])
-        difference() {
-            union() {
-                //round top
-                rotate(a = [90,0,0,]) 
-                    rotate_extrude($fn=50) 
-                        polygon(points = slotProfile);
-                //long slot
-                translate(v = [0,0,0]) 
-                    rotate(a = [180,0,0]) 
-                    union(){
-                        difference() {
-                            // Main half slot
-                            linear_extrude(height = totalHeight+1) 
-                                polygon(points = slotProfile);
-                            
-                            // Snap cutout
-                            if (slotQuickRelease == false && multiConnectVersion == "v2")
-                                translate(v= [10.15,0,0])
-                                rotate(a= [-90,0,0])
-                                linear_extrude(height = 5)  // match slot height (5mm)
-                                    polygon(points = [[0,0],[-0.4,0],[0,-8]]);  // triangle polygon with multiconnect v2 specs
-                            }
-
-                        mirror([1,0,0])
-                            difference() {
-                                // Main half slot
-                                linear_extrude(height = totalHeight+1) 
-                                    polygon(points = slotProfile);
-                                
-                                // Snap cutout
-                                if (slotQuickRelease == false && multiConnectVersion == "v2")
-                                    translate(v= [10.15,0,0])
-                                    rotate(a= [-90,0,0])
-                                    linear_extrude(height = 5)  // match slot height (5mm)
-                                        polygon(points = [[0,0],[-0.4,0],[0,-8]]);  // triangle polygon with multiconnect v2 spec
-                            }
-                    }
-                //on-ramp
-                if(onRampEnabled)
-                    for(y = [1:onRampEveryXSlots:totalHeight/distanceBetweenSlots])
-                        translate(v = [0,-5,-y*distanceBetweenSlots]) 
-                            rotate(a = [-90,0,0]) 
-                                cylinder(h = 5, r1 = 12, r2 = 10.15);
-            }
-            //dimple
-            if (slotQuickRelease == false && multiConnectVersion == "v1")
-                scale(v = dimpleScale) 
-                rotate(a = [90,0,0,]) 
-                    rotate_extrude($fn=50) 
-                        polygon(points = [[0,0],[0,1.5],[1.5,0]]);
-        }
-    }
 }
 
-module shelfBracket(bracketHeight, bracketDepth, rimThickness){
-        rotate(a = [-90,0,90]) 
-            linear_extrude(height = rimThickness) 
-                polygon([[0,0],[0,bracketHeight],[bracketDepth,bracketHeight]]);
+module createMulticonnectBackShell(distanceBetweenSlots=25, slotsWide=1, slotsHigh=1, backThickness=6.5) {
+    translate(v = [-(distanceBetweenSlots * slotsWide) / 2, -backThickness, 0]) {
+        cube([distanceBetweenSlots * slotsWide, backThickness, distanceBetweenSlots * slotsHigh]);
+    }
 }


### PR DESCRIPTION
Got started playing around with OpenSCAD for the first time and went a little overboard:
- Curved support structure (should be stronger, print faster, and use less filament)
- Allow oval objects
- Allow generation of rectangular items
- Allow the hole / slot to extend arbitrarily forward & backward - should address #27 
- Prevent the hole / slot from extending into the back wall - fixes #64 
- Allow tuning for the number of slots wide / high
- Allow tuning of the resolution of circles and curves
- Simplify / reorganize parameters

This tackles at least a few of the requests / comments that I've seen on the customizer page