### PR TITLE
Add optional screw hole caps to opengrid generator

### DIFF
--- a/openGrid/openGrid.scad
+++ b/openGrid/openGrid.scad
@@ -71,18 +71,20 @@ Screw_Every_X_Columns = 2;
 //Custom positions for screws, left to right, top to bottom. 1 = screw. Short Input defaults the rest to no screw.
 Screw_Custom_Positions = "011110";
 
-Screw_Diameter = 4.1;
+Screw_Thread_Diameter = 4.1;
 Screw_Head_Diameter = 7.2;
 Screw_Head_Inset = 1; //0.1
 Screw_Head_Is_CounterSunk = true;
 Screw_Head_CounterSunk_Degree = 90;
-//Generate screw caps to cover holes after installation, enhancing the appearance of the board.
+//Generate caps to hide mounting holes after installation, enhancing the appearance of the board.
 Generate_Screw_Cap = false;
-//If Generate_Screw_Cap is enabled, Screw_Head_Inset would increase to accommodate cap thickness.
+//When screw caps are enabled, Screw_Head_Inset increases automatically to accommodate the cap.
 Screw_Cap_Thickness = 1; //0.1
+//Thinning the center of the cap, allowing a tweezer to poke through for easy removal. Set to 0 to disable.
+Screw_Cap_Middle_Thinning = 0.6;
 //Increase this value if screw caps are too tight, decrease if they are too loose.
 Screw_Cap_Tolerance = 0.1; //0.01
-//Align caps to the top of the board, convenient when printing facing down.
+//Flip and align caps to the top of the board, convenient when printing facing down.
 Screw_Cap_Print_Orientation_Flip = false;
 
 /*[Adhesive Base Options]*/
@@ -521,9 +523,9 @@ module applyTileCornerModifications(Board_Width, Board_Height, tileSize = 28, Ti
         }
     }
     module screw_hole() {
-        Total_Screw_Inset = Generate_Screw_Cap && Stack_Count == 1 ? Screw_Cap_Thickness + Screw_Head_Inset : Screw_Head_Inset;
+        Final_Screw_Head_Inset = max(0.01,(Generate_Screw_Cap && Screw_Cap_Thickness > 0 && Stack_Count == 1 && Full_or_Lite != "Heavy" ? max(0 , Screw_Cap_Thickness) + Screw_Head_Inset : Screw_Head_Inset));
         //idea for screw hole caps comes from Gavin F
-        if (Generate_Screw_Cap && Stack_Count == 1 && Full_or_Lite != "Heavy") {
+        if (Generate_Screw_Cap && Screw_Cap_Thickness > 0 && Stack_Count == 1 && Full_or_Lite != "Heavy") {
             Screw_Cap_Up_Distance =
                 Screw_Cap_Print_Orientation_Flip ? Tile_Thickness
                 : Full_or_Lite == "Lite" ? Tile_Thickness - Lite_Tile_Thickness
@@ -532,15 +534,17 @@ module applyTileCornerModifications(Board_Width, Board_Height, tileSize = 28, Ti
                 right(Tile_Size / 2) fwd(Tile_Size / 2) 
                     up(Screw_Cap_Up_Distance) xrot(Screw_Cap_Print_Orientation_Flip?180:0)
                             tag("")cyl(l=Screw_Cap_Thickness, d=Screw_Head_Diameter - Screw_Cap_Tolerance, $fn=64,anchor=BOTTOM)
+                            if(Screw_Cap_Middle_Thinning > 0)
                                 attach(TOP,TOP,inside=true)
-                                    tag("remove")cyl(l=Screw_Cap_Thickness-0.2, d=2.2, $fn=64);
+                                    tag("remove")cyl(l=Screw_Cap_Middle_Thinning, d=3, $fn=64);
         }
-        tag("remove")
-            up(Tile_Thickness + 0.01)
-                cyl(d=Screw_Head_Diameter, h=Total_Screw_Inset > 0 ? Total_Screw_Inset : 0.01, anchor=TOP, $fn=64) {
-                    up(0.005) attach(BOT, TOP) cyl(d2=Screw_Head_Diameter, d1=Screw_Diameter, h=Screw_Head_Is_CounterSunk ? tan((180 - Screw_Head_CounterSunk_Degree) / 2) * (Screw_Head_Diameter - Screw_Diameter) / 2 : 0.01, $fn=64)
-                                attach(BOT, TOP) cyl(d=Screw_Diameter, h=Tile_Thickness + 0.02, $fn=64);
-                }
+        if(Screw_Head_Diameter > 0)
+            tag("remove")
+                up(Tile_Thickness + 0.01)
+                    cyl(d=Screw_Head_Diameter, h=Final_Screw_Head_Inset, anchor=TOP, $fn=64) 
+                        if(Screw_Thread_Diameter > 0)
+                            up(0.005) attach(BOT, TOP) cyl(d2=Screw_Head_Diameter, d1=Screw_Thread_Diameter, h=Screw_Head_Is_CounterSunk ? min(100, max(0.01, tan((180 - Screw_Head_CounterSunk_Degree) / 2) * (Screw_Head_Diameter - Screw_Thread_Diameter) / 2)) : 0.01, $fn=64)
+                                    attach(BOT, TOP) cyl(d=Screw_Thread_Diameter, h=Tile_Thickness + 0.02, $fn=64);
     }
   children();
 }

--- a/openGrid/openGrid.scad
+++ b/openGrid/openGrid.scad
@@ -73,9 +73,19 @@ Screw_Custom_Positions = "011110";
 
 Screw_Diameter = 4.1;
 Screw_Head_Diameter = 7.2;
-Screw_Head_Inset = 1;
+Screw_Head_Inset = 1; //0.1
 Screw_Head_Is_CounterSunk = true;
 Screw_Head_CounterSunk_Degree = 90;
+//Screw caps to cover screw holes after installation, enhancing the appearance of the openGrid board.
+Generate_Screw_Cap = false;
+//Notches make uninstalling screw caps easier. They are covered and do not affect the appearance unless used.
+Generate_Screw_Cap_Hidden_Notch = false;
+//When 'Generate Screw Cap' is checked, the depth of the screw hole will account for the screw cap thickness.
+Screw_Cap_Thickness = 1; //0.1
+//Tolerance for the screw cap diameter. Adjust this value if the screw caps are too loose or too tight.
+Screw_Cap_Tolerance = 0.1; //0.01
+//Align caps to the top of the board, convenient for printing facing down. Of course, you can also split the objects and adjust the orientation in the slicer.
+Screw_Cap_Print_Orientation_Flip = false;
 
 /*[Adhesive Base Options]*/
 //[Lite only] Adds a backing which allows you to adhere with double sided tape
@@ -339,7 +349,6 @@ module openGrid(Board_Width, Board_Height, tileSize = 28, Tile_Thickness = 6.8, 
         //end diff
         children();
     }
-
     //BEGIN CUTOUT TOOL
     module connector_cutout_delete_tool(anchor = CENTER, spin = 0, orient = UP) {
         //Begin connector cutout profile
@@ -494,39 +503,48 @@ module applyTileCornerModifications(Board_Width, Board_Height, tileSize = 28, Ti
                         cuboid([tileChamfer, tileChamfer, Tile_Thickness + 0.02], anchor=BOT);
     //Screw Mount Corners
     if (Screw_Mounting == "Corners")
-        tag("remove")
-            move_copies([[tileSize * Board_Width / 2 - tileSize, tileSize * Board_Height / 2 - tileSize, 0], [-tileSize * Board_Width / 2 + tileSize, tileSize * Board_Height / 2 - tileSize, 0], [tileSize * Board_Width / 2 - tileSize, -tileSize * Board_Height / 2 + tileSize, 0], [-tileSize * Board_Width / 2 + tileSize, -tileSize * Board_Height / 2 + tileSize, 0]])
-                up(Tile_Thickness + 0.01)
-                    cyl(d=Screw_Head_Diameter, h=Screw_Head_Inset > 0 ? Screw_Head_Inset : 0.01, anchor=TOP)
-                        attach(BOT, TOP) cyl(d2=Screw_Head_Diameter, d1=Screw_Diameter, h=Screw_Head_Is_CounterSunk ? tan((180 - Screw_Head_CounterSunk_Degree) / 2) * (Screw_Head_Diameter / 2 - Screw_Diameter / 2) - 0.01 : 0.01)
-                                attach(BOT, TOP) cyl(d=Screw_Diameter, h=Tile_Thickness + 0.02);
+        move_copies([[tileSize * Board_Width / 2 - tileSize, tileSize * Board_Height / 2 - tileSize, 0], [-tileSize * Board_Width / 2 + tileSize, tileSize * Board_Height / 2 - tileSize, 0], [tileSize * Board_Width / 2 - tileSize, -tileSize * Board_Height / 2 + tileSize, 0], [-tileSize * Board_Width / 2 + tileSize, -tileSize * Board_Height / 2 + tileSize, 0]])
+            screw_hole();
     //Screw Mount Everywhere
     if (Screw_Mounting == "Everywhere")
-        tag("remove")
-            grid_copies(spacing=tileSize, size=[(Board_Width - 2) * tileSize, (Board_Height - 2) * tileSize]) up(Tile_Thickness + 0.01)
-                    cyl(d=Screw_Head_Diameter, h=Screw_Head_Inset > 0 ? Screw_Head_Inset : 0.01, anchor=TOP)
-                        attach(BOT, TOP) cyl(d2=Screw_Head_Diameter, d1=Screw_Diameter, h=Screw_Head_Is_CounterSunk ? tan((180 - Screw_Head_CounterSunk_Degree) / 2) * (Screw_Head_Diameter / 2 - Screw_Diameter / 2) - 0.01 : 0.01)
-                                attach(BOT, TOP) cyl(d=Screw_Diameter, h=Tile_Thickness + 0.02);
+        grid_copies(spacing=tileSize, size=[(Board_Width - 2) * tileSize, (Board_Height - 2) * tileSize])
+            screw_hole();
     if (Screw_Mounting == "By Row and Column")
         translate([(Board_Width - 2) % max(1, Screw_Every_X_Columns) % 2 == 0 ? 0 : -tileSize / 2, (Board_Height - 2) % max(1, Screw_Every_X_Rows) % 2 == 0 ? 0 : tileSize / 2])
-            tag("remove") grid_copies(spacing=[tileSize * max(1, Screw_Every_X_Columns), tileSize * max(1, Screw_Every_X_Rows)], size=[(Board_Width - 2) * tileSize, (Board_Height - 2) * tileSize])
-                    up(Tile_Thickness + 0.01) cyl(d=Screw_Head_Diameter, h=Screw_Head_Inset > 0 ? Screw_Head_Inset : 0.01, anchor=TOP)
-                            attach(BOT, TOP) cyl(d2=Screw_Head_Diameter, d1=Screw_Diameter, h=Screw_Head_Is_CounterSunk ? tan((180 - Screw_Head_CounterSunk_Degree) / 2) * (Screw_Head_Diameter / 2 - Screw_Diameter / 2) - 0.01 : 0.01)
-                                    attach(BOT, TOP) cyl(d=Screw_Diameter, h=Tile_Thickness + 0.02);
+            grid_copies(spacing=[tileSize * max(1, Screw_Every_X_Columns), tileSize * max(1, Screw_Every_X_Rows)], size=[(Board_Width - 2) * tileSize, (Board_Height - 2) * tileSize])
+                screw_hole();
     if (Screw_Mounting == "Custom") {
         start_point_x = -(Board_Width - 2) / 2 * tileSize;
         start_point_y = (Board_Height - 2) / 2 * tileSize;
         for (i = [0:min(len(Screw_Custom_Positions), (Board_Width - 1) * (Board_Height - 1)) - 1]) {
-            if (Screw_Custom_Positions[i] == "1") {
-                tag("remove")
-                    move_copies([[start_point_x + tileSize * (i % (Board_Width - 1)), start_point_y - tileSize * floor(i / (Board_Width - 1)), 0]])
-                        up(Tile_Thickness + 0.01) cyl(d=Screw_Head_Diameter, h=Screw_Head_Inset > 0 ? Screw_Head_Inset : 0.01, anchor=TOP)
-                                attach(BOT, TOP) cyl(d2=Screw_Head_Diameter, d1=Screw_Diameter, h=Screw_Head_Is_CounterSunk ? tan((180 - Screw_Head_CounterSunk_Degree) / 2) * (Screw_Head_Diameter / 2 - Screw_Diameter / 2) - 0.01 : 0.01)
-                                        attach(BOT, TOP) cyl(d=Screw_Diameter, h=Tile_Thickness + 0.02);
-            }
+            if (Screw_Custom_Positions[i] == "1")
+                move_copies([[start_point_x + tileSize * (i % (Board_Width - 1)), start_point_y - tileSize * floor(i / (Board_Width - 1)), 0]])
+                    screw_hole();
         }
     }
-
+    module screw_hole() {
+        Total_Screw_Inset = Generate_Screw_Cap && Stack_Count == 1 ? Screw_Cap_Thickness + Screw_Head_Inset : Screw_Head_Inset;
+        //idea for screw hole caps comes from Gavin F
+        if (Generate_Screw_Cap && Stack_Count == 1) {
+            Screw_Cap_Up_Distance =
+                Screw_Cap_Print_Orientation_Flip ? Tile_Thickness - Screw_Cap_Thickness / 2
+                : Full_or_Lite == "Full" ? Screw_Cap_Thickness / 2
+                : Screw_Cap_Thickness / 2 + Tile_Thickness - Lite_Tile_Thickness;
+            tag("keep")
+                right(Tile_Size / 2) fwd(Tile_Size / 2) up(Screw_Cap_Up_Distance)
+                            cyl(l=Screw_Cap_Thickness, d=Screw_Head_Diameter - Screw_Cap_Tolerance, $fn=64);
+        }
+        tag("remove")
+            up(Tile_Thickness + 0.01)
+                cyl(d=Screw_Head_Diameter, h=Total_Screw_Inset > 0 ? Total_Screw_Inset : 0.01, anchor=TOP, $fn=64) {
+                    up(0.005) attach(BOT, TOP) cyl(d2=Screw_Head_Diameter, d1=Screw_Diameter, h=Screw_Head_Is_CounterSunk ? tan((180 - Screw_Head_CounterSunk_Degree) / 2) * (Screw_Head_Diameter - Screw_Diameter) / 2 : 0.01, $fn=64)
+                                attach(BOT, TOP) cyl(d=Screw_Diameter, h=Tile_Thickness + 0.02, $fn=64);
+                    if (Total_Screw_Inset > 0 && Generate_Screw_Cap_Hidden_Notch){
+                        fwd(1.2) attach(FRONT, FRONT, align=TOP, inset=0.2, inside=true) cuboid([1, 2, Total_Screw_Inset - 0.2]);
+                        back(1.2) attach(BACK, BACK, align=TOP, inset=0.2, inside=true) cuboid([1, 2, Total_Screw_Inset - 0.2]);
+                    }
+                }
+    }
   children();
 }
 


### PR DESCRIPTION
The idea for screw hole caps is from Gavin F [here](https://makerworld.com/en/models/1464860-screw-hole-caps-opengrid). A stand alone parametric version already [exists](https://makerworld.com/en/models/1667908-opengrid-customizable-screw-hole-caps), but I still think it makes sense to include this as an option in grid generator. This way we can ensure the size of holes and caps corresponds to each other, and moreover, even though the purpose of the original design is to cover unused screw holes, by automatically adding cap thickness to screw head inset there would be enough space for caps even after installing the screw. Being able to hide the screws can improve the look of opengrid boards by quite a bit.

Now with blender animation!

https://github.com/user-attachments/assets/6b4d0560-cb98-4074-aae2-dba9c192a9f0

