### PR TITLE
Rename "openGrid Full" to "openGrid Standard"

### DIFF
--- a/Deskware/Deskware_Main.scad
+++ b/Deskware/Deskware_Main.scad
@@ -86,7 +86,7 @@ Top_Plate_Lip_Width = 0.5;
 
 /*[Top Plate Customizer]*/
 Enable_Top_Plate_Customizer = false;
-Top_Plate_Customization = "Gridfinity Top"; //[Gridfinity Top, openGrid Lite Top, openGrid Full Top, Wireless Charger]
+Top_Plate_Customization = "Gridfinity Top"; //[Gridfinity Top, openGrid Lite Top, openGrid Standard Top, Wireless Charger]
 //Specify a specific grid width. Leave Zero (0) for standard.
 Custom_Grid_Width = 0;
 //Specify a specific grid width. Leave Zero (0) for standard.
@@ -730,7 +730,7 @@ module customizableTopPlateCore(width, depth, spin = 0, orient = UP, anchor=CENT
                     cuboid([Custom_Grid_Depth == 0 ? Available_Gridfinity_Depth_Units * 42 : Custom_Grid_Depth * 42 , Custom_Grid_Width == 0 ? Available_Gridfinity_Width_Units * 42 : Custom_Grid_Width * 42, 5]);
                 if(Top_Plate_Customization == "openGrid Lite Top")
                     cuboid([Custom_Grid_Depth == 0 ? Available_openGrid_Depth_Units * 28 : Custom_Grid_Depth * 28 , Custom_Grid_Width == 0 ? Available_openGrid_Width_Units * 28 : Custom_Grid_Width * 28, 4]);
-                if(Top_Plate_Customization == "openGrid Full Top")
+                if(Top_Plate_Customization == "openGrid Standard Top")
                     cuboid([Custom_Grid_Depth == 0 ? Available_openGrid_Depth_Units * 28 : Custom_Grid_Depth * 28 , Custom_Grid_Width == 0 ? Available_openGrid_Width_Units * 28 : Custom_Grid_Width * 28, 6.8]);
                 if(Top_Plate_Customization == "Wireless Charger")
                     cyl(d=Wireless_Charger_Diameter, h=Wireless_Charger_Thickness)
@@ -1804,13 +1804,13 @@ module openGrid(Board_Width, Board_Height, tileSize = 28, Tile_Thickness = 6.8, 
             if(Connector_Holes){
                 if(Board_Height > 1)
                 tag("remove")
-                up(Full_or_Lite == "Full" ? Tile_Thickness/2 : Tile_Thickness-connector_cutout_height/2-lite_cutout_distance_from_top)
+                up(Standard_or_Lite == "Standard" ? Tile_Thickness/2 : Tile_Thickness-connector_cutout_height/2-lite_cutout_distance_from_top)
                 xflip_copy(offset = -tileSize*Board_Width/2-0.005)
                     ycopies(spacing=tileSize, l=Board_Height > 2 ? Board_Height*tileSize-tileSize*2 : Board_Height*tileSize - tileSize - 1)
                         connector_cutout_delete_tool(anchor=LEFT);
                 if(Board_Width > 1)
                 tag("remove")
-                up(Full_or_Lite == "Full" ? Tile_Thickness/2 : Tile_Thickness-connector_cutout_height/2-lite_cutout_distance_from_top)
+                up(Standard_or_Lite == "Standard" ? Tile_Thickness/2 : Tile_Thickness-connector_cutout_height/2-lite_cutout_distance_from_top)
                 yflip_copy(offset = -tileSize*Board_Height/2-0.005)
                     xcopies(spacing=tileSize, l=Board_Width > 2 ? Board_Width*tileSize-tileSize*2 : Board_Width*tileSize-tileSize-1)
                         zrot(90)
@@ -1884,7 +1884,7 @@ module openGrid(Board_Width, Board_Height, tileSize = 28, Tile_Thickness = 6.8, 
 
         CorderSquareWidth = sqrt(Corner_Square_Thickness^2 + Corner_Square_Thickness^2)+Intersection_Distance;
         
-        full_tile_profile = [
+        standard_tile_profile = [
             [0,0],
             [Outside_Extrusion+insideExtrusion-Inside_Grid_Top_Chamfer,0],
             [Outside_Extrusion+insideExtrusion,Inside_Grid_Top_Chamfer],
@@ -1896,7 +1896,7 @@ module openGrid(Board_Width, Board_Height, tileSize = 28, Tile_Thickness = 6.8, 
             [Outside_Extrusion+insideExtrusion-Inside_Grid_Top_Chamfer,Tile_Thickness],
             [0,Tile_Thickness]
             ];
-        full_tile_corners_profile = [
+        standard_tile_corners_profile = [
             [0,0],
             [cornerOffset-cornerChamfer,0],
             [cornerOffset,cornerChamfer],
@@ -1913,13 +1913,13 @@ module openGrid(Board_Width, Board_Height, tileSize = 28, Tile_Thickness = 6.8, 
             zrot_copies(n=4)
                 union() {
                     path_extrude2d(path_tile) 
-                        polygon(full_tile_profile);
+                        polygon(standard_tile_profile);
                     move([-tileSize/2,-tileSize/2])
                         rotate([0,0,45])
                             back(cornerOffset)
                                 rotate([90,0,0])
                                     linear_extrude(cornerOffset*2) 
-                                        polygon(full_tile_corners_profile);
+                                        polygon(standard_tile_corners_profile);
                 }
         } 
         cube([tileSize, tileSize, Tile_Thickness], anchor = BOT);

--- a/NeoGrid/Neogrid.scad
+++ b/NeoGrid/Neogrid.scad
@@ -30,7 +30,7 @@ Top_or_Bottom = "Both"; //[Top, Bottom, Both]
 /*[Base Options]*/
 //Not yet implemented
 Selected_Base = "Gridfinity"; //[Gridfinity, openGrid, Flat, None]
-openGrid_Full_or_Lite = "Lite"; //[Full, Lite]
+openGrid_Standard_or_Lite = "Lite"; //[Standard, Lite]
 //openGrid Directional Snaps are for vertical mounting and additional strength against downward forces. See arrow on bottom of snap for direction of up.
 openGrid_Directional_Snap = false;
 //Orientation of openGrid Directional Snap. See arrow on bottom for orientation of up. Rotate by selecting 1 - 4.
@@ -87,7 +87,7 @@ grid_y = 1;
 Base_Chamfer = 
     Selected_Base == "Gridfinity" && !Custom_Base_Chamfer && custom_grid_size == 0 ? 5 : //default gridfinity baseplate chamfer size
     Selected_Base == "Flat" && !Custom_Base_Chamfer ? 4 : //default flat baseplate chamfer size
-    Selected_Base == "openGrid" && !Custom_Base_Chamfer ? 3 : //default openGrid full baseplate chamfer size
+    Selected_Base == "openGrid" && !Custom_Base_Chamfer ? 3 : //default openGrid Standard baseplate chamfer size
     Custom_Base_Chamfer_Size;
 
 /*[Hidden]*/
@@ -107,8 +107,8 @@ grid_size =
 calculated_base_height = 
     Selected_Base == "Gridfinity" ? 4.75 + Added_Base_Thickness : //0.6 is the additional height for the gridfinity baseplate by default. Update this if parameterized. 
     Selected_Base == "Flat" ? Flat_Base_Thickness:
-    Selected_Base == "openGrid" && openGrid_Full_or_Lite == "Full" ? 6.8:
-    Selected_Base == "openGrid" && openGrid_Full_or_Lite == "Lite" ? 3.4:
+    Selected_Base == "openGrid" && openGrid_Standard_or_Lite == "Standard" ? 6.8:
+    Selected_Base == "openGrid" && openGrid_Standard_or_Lite == "Lite" ? 3.4:
     0;
 
 ///*[Straight Channel]*/
@@ -322,7 +322,7 @@ module neoGridBase(Channel_Length, grid_size){
             cuboid( [grid_size, Channel_Length, Flat_Base_Thickness], chamfer=0.5, except=BOT, anchor=BOT);
         if(Selected_Base == "openGrid")
             zrot(90*openGrid_Directional_Snap_Orientation)
-            openGridSnap(lite= (openGrid_Full_or_Lite == "Full" ? false : true), directional=openGrid_Directional_Snap, anchor=BOT, spin=0, orient=UP);
+            openGridSnap(lite= (openGrid_Standard_or_Lite == "Standard" ? false : true), directional=openGrid_Directional_Snap, anchor=BOT, spin=0, orient=UP);
         if(Print_Specs)
             baseText();
 }
@@ -739,11 +739,11 @@ module openGridSnap(lite=false, directional=false, orient, anchor, spin){
 	}
 
 	w=24.80;
-	fulldiff=3.4;
-	h=lite ? 3.4 : fulldiff*2;
+	standard_diff=3.4;
+	h=lite ? 3.4 : standard_diff*2;
 	attachable(orient=orient, anchor=anchor, spin=spin, size=[w,w,h]){
 		zmove(-h/2) difference(){
-			core=3 + (lite ? 0 : fulldiff);
+			core=3 + (lite ? 0 : standard_diff);
 			top_h=0.4; 
 			top_nub_h=1.1;
 
@@ -759,7 +759,7 @@ module openGridSnap(lite=false, directional=false, orient, anchor, spin){
 					zrot_copies(n=4) move([w/2-offs,w/2-offs,core]) rotate([180, 0, 135]) wedge(size=[6.817,top_nub_h,top_nub_h], anchor=CENTER+BOTTOM);
 				};
 				//bottom nub
-				zmove(lite ? 0 : fulldiff) zrot_copies(n=4)
+				zmove(lite ? 0 : standard_diff) zrot_copies(n=4)
 					if (!directional || ($idx==1 || $idx==3))
 					openGridSnapNub(
 						w=w,
@@ -776,7 +776,7 @@ module openGridSnap(lite=false, directional=false, orient, anchor, spin){
 				//directional nubs 
 				 if (directional) {
 					//front directional nub
-					zmove(lite ? 0 : fulldiff) openGridSnapNub(
+					zmove(lite ? 0 : standard_diff) openGridSnapNub(
 						w=w,
 						nub_h=0,
 						nub_w=14,
@@ -790,7 +790,7 @@ module openGridSnap(lite=false, directional=false, orient, anchor, spin){
 					);
 					 
 					//rear directional nub
-					zrot(180) zmove(lite ? 0 : fulldiff) openGridSnapNub(
+					zrot(180) zmove(lite ? 0 : standard_diff) openGridSnapNub(
 						w=w,
 						nub_h=0.65,
 						nub_w=10.8,
@@ -808,17 +808,17 @@ module openGridSnap(lite=false, directional=false, orient, anchor, spin){
 			zrot_copies(n=4)
 				move([w/2-1, 0, 0])
 				if (!directional || $idx==1 || $idx==3)
-					cuboid([0.6,12.4,2.8 + (lite ? 0 : fulldiff)], rounding=0.3, $fn=100, edges="Z", anchor=BOTTOM);
+					cuboid([0.6,12.4,2.8 + (lite ? 0 : standard_diff)], rounding=0.3, $fn=100, edges="Z", anchor=BOTTOM);
 			//bottom click holes for rear directional
 			if (directional) {
-				zrot(180) move([w/2-1, 0, 0.599]) cuboid([0.6, 12.4, 2.2 + (lite ? 0 : fulldiff) ], rounding=0.3, $fn=100, edges="Z", anchor=BOTTOM);
+				zrot(180) move([w/2-1, 0, 0.599]) cuboid([0.6, 12.4, 2.2 + (lite ? 0 : standard_diff) ], rounding=0.3, $fn=100, edges="Z", anchor=BOTTOM);
 				zrot(180) move([w/2-1.2, 0, 0]) prismoid(size1=[0.6, 12.4], size2=[0.6, 12.4], h=0.6, shift=[0.2,0], rounding=0.3, $fn=100);
 				zrot(180) move([w/2-0.1, 0, 0]) rotate([0,0,0]) prismoid(size1=[0.2, 20], size2=[0, 20], shift=[0.1,0], h=0.6, anchor=BOTTOM);
 			};
 
 			//bottom wall click holes
 			zrot_copies(n=4)
-				move([w/2, 0, 2.2 + (lite ? 0 : fulldiff)])
+				move([w/2, 0, 2.2 + (lite ? 0 : standard_diff)])
 				if (!directional || ($idx>0))
 					cuboid([1.4,12,0.4], anchor=BOTTOM);
 

--- a/Underware/UnderwareInProgress/hooksAndGroves.scad
+++ b/Underware/UnderwareInProgress/hooksAndGroves.scad
@@ -45,7 +45,7 @@ Chamfer = 1; //0.1
 /*[Advanced - Tile Parameters]*/
 //Customize tile sizes - openGrid standard is 28mm
 Tile_Size = 28;
-//Thickness of the tile (full only)
+//Thickness of the tile (standard only)
 Tile_Thickness = 6.8;
 
 /*[Advanced - Slot Customization]*/

--- a/Underware/Underware_keyholes.scad
+++ b/Underware/Underware_keyholes.scad
@@ -23,7 +23,7 @@ include <BOSL2/rounding.scad>
 include <BOSL2/threading.scad>
 
 /*[Choose Part]*/
-Mounting_Surface = "Multiboard"; //[Multiboard, openGrid - Lite, openGrid - Full]
+Mounting_Surface = "Multiboard"; //[Multiboard, openGrid - Lite, openGrid - Standard]
 
 //How do you intend to mount the channels to a surface such as Honeycomb Storage Wall or Multiboard? See options at https://handsonkatie.com/underware-2-0-the-made-to-measure-collection/
 Show_Part = "Snap Keyhole"; // [Snap Keyhole, Keyhole Test]
@@ -312,11 +312,11 @@ module openGridSnap(lite=false, directional=false, orient, anchor, spin){
 	}
 
 	w=24.80;
-	fulldiff=3.4;
-	h=lite ? 3.4 : fulldiff*2;
+	standard_diff=3.4;
+	h=lite ? 3.4 : standard_diff*2;
 	attachable(orient=orient, anchor=anchor, spin=spin, size=[w,w,h]){
 		zmove(-h/2) difference(){
-			core=3 + (lite ? 0 : fulldiff);
+			core=3 + (lite ? 0 : standard_diff);
 			top_h=0.4; 
 			top_nub_h=1.1;
 
@@ -332,7 +332,7 @@ module openGridSnap(lite=false, directional=false, orient, anchor, spin){
 					zrot_copies(n=4) move([w/2-offs,w/2-offs,core]) rotate([180, 0, 135]) wedge(size=[6.817,top_nub_h,top_nub_h], anchor=CENTER+BOTTOM);
 				};
 				//bottom nub
-				zmove(lite ? 0 : fulldiff) zrot_copies(n=4)
+				zmove(lite ? 0 : standard_diff) zrot_copies(n=4)
 					if (!directional || ($idx==1 || $idx==3))
 					openGridSnapNub(
 						w=w,
@@ -349,7 +349,7 @@ module openGridSnap(lite=false, directional=false, orient, anchor, spin){
 				//directional nubs 
 				 if (directional) {
 					//front directional nub
-					zmove(lite ? 0 : fulldiff) openGridSnapNub(
+					zmove(lite ? 0 : standard_diff) openGridSnapNub(
 						w=w,
 						nub_h=0,
 						nub_w=14,
@@ -363,7 +363,7 @@ module openGridSnap(lite=false, directional=false, orient, anchor, spin){
 					);
 					 
 					//rear directional nub
-					zrot(180) zmove(lite ? 0 : fulldiff) openGridSnapNub(
+					zrot(180) zmove(lite ? 0 : standard_diff) openGridSnapNub(
 						w=w,
 						nub_h=0.65,
 						nub_w=10.8,
@@ -381,17 +381,17 @@ module openGridSnap(lite=false, directional=false, orient, anchor, spin){
 			zrot_copies(n=4)
 				move([w/2-1, 0, 0])
 				if (!directional || $idx==1 || $idx==3)
-					cuboid([0.6,12.4,2.8 + (lite ? 0 : fulldiff)], rounding=0.3, $fn=100, edges="Z", anchor=BOTTOM);
+					cuboid([0.6,12.4,2.8 + (lite ? 0 : standard_diff)], rounding=0.3, $fn=100, edges="Z", anchor=BOTTOM);
 			//bottom click holes for rear directional
 			if (directional) {
-				zrot(180) move([w/2-1, 0, 0.599]) cuboid([0.6, 12.4, 2.2 + (lite ? 0 : fulldiff) ], rounding=0.3, $fn=100, edges="Z", anchor=BOTTOM);
+				zrot(180) move([w/2-1, 0, 0.599]) cuboid([0.6, 12.4, 2.2 + (lite ? 0 : standard_diff) ], rounding=0.3, $fn=100, edges="Z", anchor=BOTTOM);
 				zrot(180) move([w/2-1.2, 0, 0]) prismoid(size1=[0.6, 12.4], size2=[0.6, 12.4], h=0.6, shift=[0.2,0], rounding=0.3, $fn=100);
 				zrot(180) move([w/2-0.1, 0, 0]) rotate([0,0,0]) prismoid(size1=[0.2, 20], size2=[0, 20], shift=[0.1,0], h=0.6, anchor=BOTTOM);
 			};
 
 			//bottom wall click holes
 			zrot_copies(n=4)
-				move([w/2, 0, 2.2 + (lite ? 0 : fulldiff)])
+				move([w/2, 0, 2.2 + (lite ? 0 : standard_diff)])
 				if (!directional || ($idx>0))
 					cuboid([1.4,12,0.4], anchor=BOTTOM);
 

--- a/openGrid/openGrid-border.scad
+++ b/openGrid/openGrid-border.scad
@@ -15,7 +15,7 @@ Change Log:
 include <BOSL2/std.scad>
 
 /*[Border Configuration]*/
-Full_or_Lite = "Lite"; // [Full, Lite]
+Standard_or_Lite = "Lite"; // [Standard, Lite]
 // Length of border in cells
 Border_width = 2;
 // Border thickness (min 5.2mm)
@@ -39,9 +39,9 @@ Tile_Size = 28;
 Connector_Depth = Connector_Protrusion; // How far the cutout goes inward (Z axis)
 Connector_Width = 3.9;                  // Width of connector cutout (match openGrid)
 Connector_Height = 2.0;                 // Height of connector cutout
-Full_Tile_Thickness = 6.8;
+Standard_Tile_Thickness = 6.8;
 Lite_Tile_Thickness = 4;
-Selected_Tile_Thickness = Full_or_Lite == "Full" ? Full_Tile_Thickness : Lite_Tile_Thickness;
+Selected_Tile_Thickness = Standard_or_Lite == "Standard" ? Standard_Tile_Thickness : Lite_Tile_Thickness;
 // Thinner than 5.2mm and the hole for the connector pokes through.
 // TODO: Could we have a connector printed into the part (positive instead of a negative)? Maybe a short connector since it's not weight bearing?
 Selected_Border_Thickness = max(5.2, Border_thickness);

--- a/openGrid/openGrid.scad
+++ b/openGrid/openGrid.scad
@@ -45,7 +45,7 @@ Credit to
 include <BOSL2/std.scad>
 
 /*[Board Size]*/
-Full_or_Lite = "Lite"; //[Full, Lite, Heavy]
+Standard_or_Lite = "Lite"; //[Standard, Lite, Heavy]
 Board_Width = 2;
 Board_Height = 2;
 
@@ -119,21 +119,21 @@ if (Fill_Space_Mode == "Fill Available Space")
 
 //GENERATE SINGLE TILES
 if (Fill_Space_Mode == "None") {
-    if (Full_or_Lite == "Full" && adjustedStackCount == 1) openGrid(Board_Width=Board_Width, Board_Height=Board_Height, tileSize=Tile_Size, Tile_Thickness=Tile_Thickness, Screw_Mounting=Screw_Mounting, Chamfers=Chamfers, Add_Adhesive_Base=Add_Adhesive_Base, anchor=BOT, Connector_Holes=Connector_Holes);
-    if (Full_or_Lite == "Lite" && adjustedStackCount == 1) openGridLite(Board_Width=Board_Width, Board_Height=Board_Height, tileSize=Tile_Size, Screw_Mounting=Screw_Mounting, Chamfers=Chamfers, Add_Adhesive_Base=Add_Adhesive_Base, anchor=BOT, Connector_Holes=Connector_Holes);
-    if (Full_or_Lite == "Heavy" && adjustedStackCount == 1) openGridHeavy(Board_Width=Board_Width, Board_Height=Board_Height, tileSize=Tile_Size, Screw_Mounting=Screw_Mounting, Chamfers=Chamfers, anchor=BOT, Connector_Holes=Connector_Holes);
+    if (Standard_or_Lite == "Standard" && adjustedStackCount == 1) openGrid(Board_Width=Board_Width, Board_Height=Board_Height, tileSize=Tile_Size, Tile_Thickness=Tile_Thickness, Screw_Mounting=Screw_Mounting, Chamfers=Chamfers, Add_Adhesive_Base=Add_Adhesive_Base, anchor=BOT, Connector_Holes=Connector_Holes);
+    if (Standard_or_Lite == "Lite" && adjustedStackCount == 1) openGridLite(Board_Width=Board_Width, Board_Height=Board_Height, tileSize=Tile_Size, Screw_Mounting=Screw_Mounting, Chamfers=Chamfers, Add_Adhesive_Base=Add_Adhesive_Base, anchor=BOT, Connector_Holes=Connector_Holes);
+    if (Standard_or_Lite == "Heavy" && adjustedStackCount == 1) openGridHeavy(Board_Width=Board_Width, Board_Height=Board_Height, tileSize=Tile_Size, Screw_Mounting=Screw_Mounting, Chamfers=Chamfers, anchor=BOT, Connector_Holes=Connector_Holes);
 
     //GENERATE STACKED TILES
-    if (Full_or_Lite == "Full" && adjustedStackCount > 1) {
+    if (Standard_or_Lite == "Standard" && adjustedStackCount > 1) {
         zcopies(spacing=Tile_Thickness + adjustedInterfaceThickness + 2 * Interface_Separation, n=adjustedStackCount, sp=[0, 0, Tile_Thickness])
             zflip()
                 openGrid(Board_Width=Board_Width, Board_Height=Board_Height, tileSize=Tile_Size, Tile_Thickness=Tile_Thickness, Screw_Mounting=Screw_Mounting, Chamfers=Chamfers, anchor=BOT, Connector_Holes=Connector_Holes);
         if (Stacking_Method == "Interface Layer")
             zcopies(spacing=Tile_Thickness + adjustedInterfaceThickness + 2 * Interface_Separation, n=adjustedStackCount - 1, sp=[0, 0, Tile_Thickness + Interface_Separation])
-                color("red") interfaceLayer(Board_Width=Board_Width, Board_Height=Board_Height, tileSize=Tile_Size, Tile_Thickness=Tile_Thickness, Screw_Mounting=Screw_Mounting, Chamfers=Chamfers, boardType="Full", anchor=BOT);
+                color("red") interfaceLayer(Board_Width=Board_Width, Board_Height=Board_Height, tileSize=Tile_Size, Tile_Thickness=Tile_Thickness, Screw_Mounting=Screw_Mounting, Chamfers=Chamfers, boardType="Standard", anchor=BOT);
     }
 
-    if (Full_or_Lite == "Lite" && adjustedStackCount > 1) {
+    if (Standard_or_Lite == "Lite" && adjustedStackCount > 1) {
         zcopies(spacing=Lite_Tile_Thickness + adjustedInterfaceThickness + 2 * Interface_Separation, n=adjustedStackCount, sp=[0, 0, Lite_Tile_Thickness])
             openGridLite(Board_Width=Board_Width, Board_Height=Board_Height, tileSize=Tile_Size, Screw_Mounting=Screw_Mounting, Chamfers=Chamfers, Connector_Holes=Connector_Holes, anchor=$idx % 2 == 0 ? TOP : BOT, orient=$idx % 2 == 0 ? UP : DOWN);
         if (Stacking_Method == "Interface Layer")
@@ -141,7 +141,7 @@ if (Fill_Space_Mode == "None") {
                 color("red") interfaceLayer2D(Board_Width=Board_Width, Board_Height=Board_Height, tileSize=Tile_Size, Screw_Mounting=Screw_Mounting, Chamfers=Chamfers, boardType="Lite", topSide=$idx % 2 == 0 ? false : true);
     }
 
-    if (Full_or_Lite == "Heavy" && adjustedStackCount > 1) {
+    if (Standard_or_Lite == "Heavy" && adjustedStackCount > 1) {
         zcopies(spacing=Heavy_Tile_Thickness + adjustedInterfaceThickness + 2 * Interface_Separation, n=adjustedStackCount, sp=[0, 0, Heavy_Tile_Thickness])
             openGridHeavy(Board_Width=Board_Width, Board_Height=Board_Height, tileSize=Tile_Size, Screw_Mounting=Screw_Mounting, Chamfers=Chamfers, Connector_Holes=Connector_Holes, anchor=$idx % 2 == 0 ? TOP : BOT, orient=$idx % 2 == 0 ? UP : DOWN);
         if (Stacking_Method == "Interface Layer")
@@ -150,13 +150,13 @@ if (Fill_Space_Mode == "None") {
     }
 }
 
-module interfaceLayer(Board_Width, Board_Height, tileSize = 28, Tile_Thickness = 6.8, Screw_Mounting = "None", Chamfers = "None", Connector_Holes = false, anchor = CENTER, spin = 0, orient = UP, boardType = "Full") {
+module interfaceLayer(Board_Width, Board_Height, tileSize = 28, Tile_Thickness = 6.8, Screw_Mounting = "None", Chamfers = "None", Connector_Holes = false, anchor = CENTER, spin = 0, orient = UP, boardType = "Standard") {
     linear_extrude(height=Interface_Thickness)
         projection(cut=true)
             interfaceLayer2D(Board_Width=Board_Width, Board_Height=Board_Height, tileSize=tileSize, Tile_Thickness=Tile_Thickness, Screw_Mounting=Screw_Mounting, Chamfers=Chamfers, boardType=boardType);
 }
 
-module interfaceLayer2D(Board_Width, Board_Height, tileSize = 28, Tile_Thickness = 6.8, Screw_Mounting = "None", Chamfers = "None", Connector_Holes = false, anchor = CENTER, spin = 0, orient = UP, boardType = "Full", topSide = false) {
+module interfaceLayer2D(Board_Width, Board_Height, tileSize = 28, Tile_Thickness = 6.8, Screw_Mounting = "None", Chamfers = "None", Connector_Holes = false, anchor = CENTER, spin = 0, orient = UP, boardType = "Standard", topSide = false) {
     linear_extrude(height=Interface_Thickness)
         projection(cut=true)
         //bottom_half(z = 0.1, s = max(tileSize * Board_Width, tileSize * Board_Height) * 2)
@@ -302,7 +302,7 @@ module openGrid(Board_Width, Board_Height, tileSize = 28, Tile_Thickness = 6.8, 
                         //top and bottom connector holes
                         if (Board_Height > 1)
                             tag("remove")
-                                up(Full_or_Lite != "Lite" ? Tile_Thickness / 2 : Tile_Thickness - connector_cutout_height / 2 - lite_cutout_distance_from_top) {
+                                up(Standard_or_Lite != "Lite" ? Tile_Thickness / 2 : Tile_Thickness - connector_cutout_height / 2 - lite_cutout_distance_from_top) {
                                     //bottom connector holes
                                     if (Connector_Holes_Right)
                                         left(-tileSize * Board_Width / 2 - 0.005)
@@ -319,7 +319,7 @@ module openGrid(Board_Width, Board_Height, tileSize = 28, Tile_Thickness = 6.8, 
                         //right and left connector holes
                         if (Board_Width > 1)
                             tag("remove")
-                                up(Full_or_Lite != "Lite" ? Tile_Thickness / 2 : Tile_Thickness - connector_cutout_height / 2 - lite_cutout_distance_from_top) {
+                                up(Standard_or_Lite != "Lite" ? Tile_Thickness / 2 : Tile_Thickness - connector_cutout_height / 2 - lite_cutout_distance_from_top) {
                                     //right connector holes
                                     if (Connector_Holes_Top)
                                         fwd(-tileSize * Board_Height / 2 - 0.005)
@@ -407,7 +407,7 @@ module openGrid(Board_Width, Board_Height, tileSize = 28, Tile_Thickness = 6.8, 
         CorderSquareWidth = sqrt(Corner_Square_Thickness ^ 2 + Corner_Square_Thickness ^ 2) + Intersection_Distance;
 
 
-        full_tile_profile = Full_or_Lite == "Heavy" ? [
+        standard_tile_profile = Standard_or_Lite == "Heavy" ? [
             [0, 0],
             [Outside_Extrusion, 0],
             [Outside_Extrusion, Tile_Thickness - Top_Capture_Initial_Inset],
@@ -428,7 +428,7 @@ module openGrid(Board_Width, Board_Height, tileSize = 28, Tile_Thickness = 6.8, 
             [0, Tile_Thickness],
         ];
 
-        full_tile_corners_profile = [
+        standard_tile_corners_profile = [
             [0, 0],
             [cornerOffset - cornerChamfer, 0],
             [cornerOffset, cornerChamfer],
@@ -444,13 +444,13 @@ module openGrid(Board_Width, Board_Height, tileSize = 28, Tile_Thickness = 6.8, 
                 zrot_copies(n=4)
                     union() {
                         path_extrude2d(path_tile)
-                            polygon(full_tile_profile);
+                            polygon(standard_tile_profile);
                         move([-tileSize / 2, -tileSize / 2])
                             rotate([0, 0, 45])
                                 back(cornerOffset)
                                     rotate([90, 0, 0])
                                         linear_extrude(cornerOffset * 2)
-                                            polygon(full_tile_corners_profile);
+                                            polygon(standard_tile_corners_profile);
                     }
             }
             cube([tileSize, tileSize, Tile_Thickness], anchor=BOT);
@@ -556,7 +556,7 @@ module FillSpaceFullTiles() {
 
     // === Tile placement function ===
     module place_tile(x, y, w, h) {
-        translate([x * spacing_x, y * spacing_y, 0]) if (Full_or_Lite == "Full")
+        translate([x * spacing_x, y * spacing_y, 0]) if (Standard_or_Lite == "Standard")
             openGrid(
                 Board_Width=w, Board_Height=h,
                 tileSize=Tile_Size,
@@ -565,7 +565,7 @@ module FillSpaceFullTiles() {
                 Chamfers=Chamfers, anchor=BOT,
                 Connector_Holes=Connector_Holes
             );
-        else if (Full_or_Lite == "Heavy")
+        else if (Standard_or_Lite == "Heavy")
             openGridHeavy(
                 Board_Width=w, Board_Height=h,
                 tileSize=Tile_Size,
@@ -606,36 +606,36 @@ module FillSpaceFullTiles() {
 
 module FillSpaceClipOneSide() {
     /* — 1) Compute each full 8×8 tile’s size in pure millimeters (no spacing) — */
-    full_tile_width_mm = Max_Tile_Width * Tile_Size; // 8 × 28 = 224 mm
-    full_tile_depth_mm = Max_Tile_Depth * Tile_Size; // 8 × 28 = 224 mm
+    standard_tile_width_mm = Max_Tile_Width * Tile_Size; // 8 × 28 = 224 mm
+    standard_tile_depth_mm = Max_Tile_Depth * Tile_Size; // 8 × 28 = 224 mm
 
     /* — 2) Determine how many full‐width columns fit — */
-    num_full_cols = floor(Space_Width / full_tile_width_mm);
+    num_full_cols = floor(Space_Width / standard_tile_width_mm);
     // leftover width (in mm) beyond full columns
-    rem_width_mm = Space_Width - (num_full_cols * full_tile_width_mm);
+    rem_width_mm = Space_Width - (num_full_cols * standard_tile_width_mm);
     // If any leftover > 0, we’ll need one extra (clipped) column:
     num_cols = num_full_cols + (rem_width_mm > 0 ? 1 : 0);
 
     /* — 3) Determine how many full‐depth rows fit — */
-    num_full_rows = floor(Space_Depth / full_tile_depth_mm);
+    num_full_rows = floor(Space_Depth / standard_tile_depth_mm);
     // leftover depth (in mm) beyond full rows
-    rem_depth_mm = Space_Depth - (num_full_rows * full_tile_depth_mm);
+    rem_depth_mm = Space_Depth - (num_full_rows * standard_tile_depth_mm);
     // If any leftover > 0, we’ll need one extra (clipped) row:
     num_rows = num_full_rows + (rem_depth_mm > 0 ? 1 : 0);
 
     /* — 4) Build lists of X and Y origins (in mm) for each column/row —
-    //     Each origin = (i * full_tile_width_mm) + (i * Tile_Spacing)
+    //     Each origin = (i * standard_tile_width_mm) + (i * Tile_Spacing)
     //     so that the 5 mm gap is only used when positioning, not in count. — */
     X_origins = [
-        for (i = [0:num_cols - 1]) (i * full_tile_width_mm) + (i * Tile_Spacing),
+        for (i = [0:num_cols - 1]) (i * standard_tile_width_mm) + (i * Tile_Spacing),
     ];
     Y_origins = [
-        for (j = [0:num_rows - 1]) (j * full_tile_depth_mm) + (j * Tile_Spacing),
+        for (j = [0:num_rows - 1]) (j * standard_tile_depth_mm) + (j * Tile_Spacing),
     ];
 
     /* — 5) Debug echoes to verify calculation — */
     echo("Drawer interior (mm):", Space_Width, "×", Space_Depth);
-    echo("Full‐tile size  (mm):", full_tile_width_mm, "×", full_tile_depth_mm);
+    echo("Full‐tile size  (mm):", standard_tile_width_mm, "×", standard_tile_depth_mm);
     echo("num_full_cols, rem_width_mm:", num_full_cols, ",", rem_width_mm);
     echo("num_cols total (incl. clipped):", num_cols, "→ X_origins:", X_origins);
     echo("num_full_rows, rem_depth_mm:", num_full_rows, ",", rem_depth_mm);
@@ -646,8 +646,8 @@ module FillSpaceClipOneSide() {
         so we shift its center to (x_mm + half_w, y_mm + half_d). — */
     module place_centered_and_clipped(x_mm, y_mm) {
         // Half‐dimensions of an 8×8 tile (because openGrid is centered)
-        half_w = full_tile_width_mm / 2; // 224/2 = 112 mm
-        half_d = full_tile_depth_mm / 2; // 224/2 = 112 mm
+        half_w = standard_tile_width_mm / 2; // 224/2 = 112 mm
+        half_d = standard_tile_depth_mm / 2; // 224/2 = 112 mm
 
         // Center point for openGrid:
         cx = x_mm + half_w;
@@ -655,9 +655,9 @@ module FillSpaceClipOneSide() {
 
         // Naive extents (before clipping)
         x0 = cx - half_w; // = x_mm
-        x1 = cx + half_w; // = x_mm + full_tile_width_mm
+        x1 = cx + half_w; // = x_mm + standard_tile_width_mm
         y0 = cy - half_d; // = y_mm
-        y1 = cy + half_d; // = y_mm + full_tile_depth_mm
+        y1 = cy + half_d; // = y_mm + standard_tile_depth_mm
 
         // Clipped extents:
         clipped_x0 = max(x0, 0);
@@ -668,7 +668,7 @@ module FillSpaceClipOneSide() {
         // Intersection: drawer cube ∩ translated, centered openGrid(8,8)
         intersection() {
             cube([Space_Width + num_full_cols * Tile_Spacing, Space_Depth + num_full_rows * Tile_Spacing, Heavy_Tile_Thickness + 1], center=false);
-            translate([cx, cy, 0]) if (Full_or_Lite == "Full")
+            translate([cx, cy, 0]) if (Standard_or_Lite == "Standard")
                 openGrid(
                     Board_Width=Max_Tile_Width,
                     Board_Height=Max_Tile_Depth,
@@ -678,7 +678,7 @@ module FillSpaceClipOneSide() {
                     Chamfers=Chamfers, anchor=BOT,
                     Connector_Holes=Connector_Holes
                 );
-            else if (Full_or_Lite == "Heavy")
+            else if (Standard_or_Lite == "Heavy")
                 openGridHeavy(
                     Board_Width=Max_Tile_Width,
                     Board_Height=Max_Tile_Depth,

--- a/openGrid/openGrid.scad
+++ b/openGrid/openGrid.scad
@@ -606,36 +606,36 @@ module FillSpaceFullTiles() {
 
 module FillSpaceClipOneSide() {
     /* — 1) Compute each full 8×8 tile’s size in pure millimeters (no spacing) — */
-    standard_tile_width_mm = Max_Tile_Width * Tile_Size; // 8 × 28 = 224 mm
-    standard_tile_depth_mm = Max_Tile_Depth * Tile_Size; // 8 × 28 = 224 mm
+    full_tile_width_mm = Max_Tile_Width * Tile_Size; // 8 × 28 = 224 mm
+    full_tile_depth_mm = Max_Tile_Depth * Tile_Size; // 8 × 28 = 224 mm
 
     /* — 2) Determine how many full‐width columns fit — */
-    num_full_cols = floor(Space_Width / standard_tile_width_mm);
+    num_full_cols = floor(Space_Width / full_tile_width_mm);
     // leftover width (in mm) beyond full columns
-    rem_width_mm = Space_Width - (num_full_cols * standard_tile_width_mm);
+    rem_width_mm = Space_Width - (num_full_cols * full_tile_width_mm);
     // If any leftover > 0, we’ll need one extra (clipped) column:
     num_cols = num_full_cols + (rem_width_mm > 0 ? 1 : 0);
 
     /* — 3) Determine how many full‐depth rows fit — */
-    num_full_rows = floor(Space_Depth / standard_tile_depth_mm);
+    num_full_rows = floor(Space_Depth / full_tile_depth_mm);
     // leftover depth (in mm) beyond full rows
-    rem_depth_mm = Space_Depth - (num_full_rows * standard_tile_depth_mm);
+    rem_depth_mm = Space_Depth - (num_full_rows * full_tile_depth_mm);
     // If any leftover > 0, we’ll need one extra (clipped) row:
     num_rows = num_full_rows + (rem_depth_mm > 0 ? 1 : 0);
 
     /* — 4) Build lists of X and Y origins (in mm) for each column/row —
-    //     Each origin = (i * standard_tile_width_mm) + (i * Tile_Spacing)
+    //     Each origin = (i * full_tile_width_mm) + (i * Tile_Spacing)
     //     so that the 5 mm gap is only used when positioning, not in count. — */
     X_origins = [
-        for (i = [0:num_cols - 1]) (i * standard_tile_width_mm) + (i * Tile_Spacing),
+        for (i = [0:num_cols - 1]) (i * full_tile_width_mm) + (i * Tile_Spacing),
     ];
     Y_origins = [
-        for (j = [0:num_rows - 1]) (j * standard_tile_depth_mm) + (j * Tile_Spacing),
+        for (j = [0:num_rows - 1]) (j * full_tile_depth_mm) + (j * Tile_Spacing),
     ];
 
     /* — 5) Debug echoes to verify calculation — */
     echo("Drawer interior (mm):", Space_Width, "×", Space_Depth);
-    echo("Full‐tile size  (mm):", standard_tile_width_mm, "×", standard_tile_depth_mm);
+    echo("Full‐tile size  (mm):", full_tile_width_mm, "×", full_tile_depth_mm);
     echo("num_full_cols, rem_width_mm:", num_full_cols, ",", rem_width_mm);
     echo("num_cols total (incl. clipped):", num_cols, "→ X_origins:", X_origins);
     echo("num_full_rows, rem_depth_mm:", num_full_rows, ",", rem_depth_mm);
@@ -646,8 +646,8 @@ module FillSpaceClipOneSide() {
         so we shift its center to (x_mm + half_w, y_mm + half_d). — */
     module place_centered_and_clipped(x_mm, y_mm) {
         // Half‐dimensions of an 8×8 tile (because openGrid is centered)
-        half_w = standard_tile_width_mm / 2; // 224/2 = 112 mm
-        half_d = standard_tile_depth_mm / 2; // 224/2 = 112 mm
+        half_w = full_tile_width_mm / 2; // 224/2 = 112 mm
+        half_d = full_tile_depth_mm / 2; // 224/2 = 112 mm
 
         // Center point for openGrid:
         cx = x_mm + half_w;
@@ -655,9 +655,9 @@ module FillSpaceClipOneSide() {
 
         // Naive extents (before clipping)
         x0 = cx - half_w; // = x_mm
-        x1 = cx + half_w; // = x_mm + standard_tile_width_mm
+        x1 = cx + half_w; // = x_mm + full_tile_width_mm
         y0 = cy - half_d; // = y_mm
-        y1 = cy + half_d; // = y_mm + standard_tile_depth_mm
+        y1 = cy + half_d; // = y_mm + full_tile_depth_mm
 
         // Clipped extents:
         clipped_x0 = max(x0, 0);

--- a/openGrid/opengrid-snap.scad
+++ b/openGrid/opengrid-snap.scad
@@ -35,11 +35,11 @@ module openGridSnap(lite=false, directional=false, orient, anchor, spin){
 	}
 
 	w=24.80;
-	fulldiff=3.4;
-	h=lite ? 3.4 : fulldiff*2;
+	standard_diff=3.4;
+	h=lite ? 3.4 : standard_diff*2;
 	attachable(orient=orient, anchor=anchor, spin=spin, size=[w,w,h]){
 		zmove(-h/2) difference(){
-			core=3 + (lite ? 0 : fulldiff);
+			core=3 + (lite ? 0 : standard_diff);
 			top_h=0.4; 
 			top_nub_h=1.1;
 
@@ -55,7 +55,7 @@ module openGridSnap(lite=false, directional=false, orient, anchor, spin){
 					zrot_copies(n=4) move([w/2-offs,w/2-offs,core]) rotate([180, 0, 135]) wedge(size=[6.817,top_nub_h,top_nub_h], anchor=CENTER+BOTTOM);
 				};
 				//bottom nub
-				zmove(lite ? 0 : fulldiff) zrot_copies(n=4)
+				zmove(lite ? 0 : standard_diff) zrot_copies(n=4)
 					if (!directional || ($idx==1 || $idx==3))
 					openGridSnapNub(
 						w=w,
@@ -72,7 +72,7 @@ module openGridSnap(lite=false, directional=false, orient, anchor, spin){
 				//directional nubs 
 				 if (directional) {
 					//front directional nub
-					zmove(lite ? 0 : fulldiff) openGridSnapNub(
+					zmove(lite ? 0 : standard_diff) openGridSnapNub(
 						w=w,
 						nub_h=0,
 						nub_w=14,
@@ -86,7 +86,7 @@ module openGridSnap(lite=false, directional=false, orient, anchor, spin){
 					);
 					 
 					//rear directional nub
-					zrot(180) zmove(lite ? 0 : fulldiff) openGridSnapNub(
+					zrot(180) zmove(lite ? 0 : standard_diff) openGridSnapNub(
 						w=w,
 						nub_h=0.65,
 						nub_w=10.8,
@@ -104,17 +104,17 @@ module openGridSnap(lite=false, directional=false, orient, anchor, spin){
 			zrot_copies(n=4)
 				move([w/2-1, 0, 0])
 				if (!directional || $idx==1 || $idx==3)
-					cuboid([0.6,12.4,2.8 + (lite ? 0 : fulldiff)], rounding=0.3, $fn=100, edges="Z", anchor=BOTTOM);
+					cuboid([0.6,12.4,2.8 + (lite ? 0 : standard_diff)], rounding=0.3, $fn=100, edges="Z", anchor=BOTTOM);
 			//bottom click holes for rear directional
 			if (directional) {
-				zrot(180) move([w/2-1, 0, 0.599]) cuboid([0.6, 12.4, 2.2 + (lite ? 0 : fulldiff) ], rounding=0.3, $fn=100, edges="Z", anchor=BOTTOM);
+				zrot(180) move([w/2-1, 0, 0.599]) cuboid([0.6, 12.4, 2.2 + (lite ? 0 : standard_diff) ], rounding=0.3, $fn=100, edges="Z", anchor=BOTTOM);
 				zrot(180) move([w/2-1.2, 0, 0]) prismoid(size1=[0.6, 12.4], size2=[0.6, 12.4], h=0.6, shift=[0.2,0], rounding=0.3, $fn=100);
 				zrot(180) move([w/2-0.1, 0, 0]) rotate([0,0,0]) prismoid(size1=[0.2, 20], size2=[0, 20], shift=[0.1,0], h=0.6, anchor=BOTTOM);
 			};
 
 			//bottom wall click holes
 			zrot_copies(n=4)
-				move([w/2, 0, 2.2 + (lite ? 0 : fulldiff)])
+				move([w/2, 0, 2.2 + (lite ? 0 : standard_diff)])
 				if (!directional || ($idx>0))
 					cuboid([1.4,12,0.4], anchor=BOTTOM);
 


### PR DESCRIPTION
With the addition of KYZ's openGrid Heavy board (13.6mm thick), I feel that calling the 6.8mm version "Full" is a bit confusing. I changed references of "openGrid Full" to "openGrid Standard." What do you think?